### PR TITLE
Changed the node naming ui

### DIFF
--- a/elfi/graphical_model.py
+++ b/elfi/graphical_model.py
@@ -9,7 +9,7 @@ class GraphicalModel:
         self.source_net = source_net or nx.DiGraph()
 
     def add_node(self, name, state):
-        if self.source_net.has_node(name):
+        if self.has_node(name):
             raise ValueError('Node {} already exists'.format(name))
         self.source_net.add_node(name, attr_dict=state)
 
@@ -22,14 +22,17 @@ class GraphicalModel:
         """
         return self.source_net.node[name]
 
+    def has_node(self, name):
+        return self.source_net.has_node(name)
+
     def add_edge(self, parent_name, child_name, param=None):
         # By default, map to a positional parameter of the child
         if param is None:
             param = len(self.source_net.predecessors(child_name))
 
-        if not self.source_net.has_node(parent_name):
+        if not self.has_node(parent_name):
             raise ValueError('Parent {} does not exist'.format(parent_name))
-        if not self.source_net.has_node(child_name):
+        if not self.has_node(child_name):
             raise ValueError('Child {} does not exist'.format(child_name))
 
         self.source_net.add_edge(parent_name, child_name, param=param)

--- a/examples/ma2.py
+++ b/examples/ma2.py
@@ -56,14 +56,12 @@ def get_model(n_obs=100, true_params=None, seed_obs=None):
     sim_fn = partial(MA2, n_obs=n_obs)
 
     m = elfi.ElfiModel()
-
-    t1 = elfi.Prior('t1', CustomPrior1, 2, model=m)
-    t2 = elfi.Prior('t2', CustomPrior2, t1, 1, model=m)
-    Y = elfi.Simulator('MA2', sim_fn, t1, t2, observed=y, model=m)
-    S1 = elfi.Summary('S1', autocov, Y, model=m)
-    S2 = elfi.Summary('S2', autocov, Y, 2, model=m)
-    d = elfi.Discrepancy('d', discrepancy, S1, S2, model=m)
-
+    elfi.Prior(CustomPrior1, 2, model=m, name='t1')
+    elfi.Prior(CustomPrior2, m['t1'], 1, model=m, name='t2')
+    elfi.Simulator(sim_fn, m['t1'], m['t2'], observed=y, model=m, name='MA2')
+    elfi.Summary(autocov, m['MA2'], model=m, name='S1')
+    elfi.Summary(autocov, m['MA2'], 2, model=m, name='S2')
+    elfi.Discrepancy(discrepancy, m['S1'], m['S2'], model=m, name='d')
     return m
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -66,9 +66,9 @@ def use_logging():
 @pytest.fixture()
 def simple_model():
     m = elfi.ElfiModel()
-    tau = elfi.Constant('tau', 10, model=m)
-    k1 = elfi.Prior('k1', 'uniform', 0, tau, size=1, model=m)
-    k2 = elfi.Prior('k2', 'normal', k1, size=3, model=m)
+    elfi.Constant(10, model=m, name='tau')
+    elfi.Prior('uniform', 0, m['tau'], size=1, model=m, name='k1')
+    elfi.Prior('normal', m['k1'], size=3, model=m, name='k2')
     return m
 
 
@@ -90,9 +90,10 @@ def sleep_model(request):
     """
     ub_sec = request.param or .5
     m = elfi.ElfiModel()
-    ub = elfi.Constant('ub', ub_sec, model=m)
-    sec = elfi.Prior('sec', 'uniform', 0, ub, model=m)
-    slept = elfi.Simulator('slept', sleeper, sec, model=m)
-    d = elfi.Discrepancy('d',  examples.ma2.discrepancy, slept, model=m)
+    elfi.Constant(ub_sec, model=m, name='ub')
+    elfi.Prior('uniform', 0, m['ub'], model=m, name='sec')
+    elfi.Simulator(sleeper, m['sec'], model=m, name='slept')
+    elfi.Discrepancy(examples.ma2.discrepancy, m['slept'], model=m, name='d')
+
     m.observed['slept'] = ub_sec/2
     return m

--- a/tests/functional/test_inference.py
+++ b/tests/functional/test_inference.py
@@ -83,7 +83,7 @@ def test_bayesian_optimization():
     m, true_params = setup_ma2_with_informative_data()
 
     # Log distance tends to work better
-    log_d = NodeReference('log_d', m['d'], state=dict(fn=np.log), model=m)
+    log_d = NodeReference(m['d'], state=dict(fn=np.log), model=m, name='log_d')
 
     bo = elfi.BayesianOptimization(log_d,
                                    n_acq=300,

--- a/tests/unit/test_elfi_model.py
+++ b/tests/unit/test_elfi_model.py
@@ -9,5 +9,30 @@ import elfi.model.elfi_model as em
 def test_node_reference_str():
     # This is important because it is used when passing NodeReferences as InferenceMethod
     # arguments
-    ref = em.NodeReference('test')
+    ref = em.NodeReference(name='test')
     assert str(ref) == 'test'
+
+
+def test_name_determination():
+    node = em.NodeReference()
+    assert node.name == 'node'
+
+    # Works without spaces
+    node2=em.NodeReference()
+    assert node2.name == 'node2'
+
+    # Does not give the same name
+    node = em.NodeReference()
+    assert node.name != 'node'
+
+    # Works with sub classes
+    pri = em.Prior()
+    assert pri.name == 'pri'
+
+    # Assigns random names when the name isn't self explanatory
+    nodes = []
+    for i in range(5):
+        nodes.append(em.NodeReference())
+
+    for i in range(1,5):
+        assert nodes[i-1].name != nodes[i].name


### PR DESCRIPTION
Before:
`t1 = Prior('t1', ...)`
Now:
`t1 = Prior(..., name='t1')`
Or
`t1 = Prior(...)`

In the last case the name is inferred automatically with `inspect`
