### PR TITLE
Node output size refactoring

### DIFF
--- a/elfi/bo/gpy_regression.py
+++ b/elfi/bo/gpy_regression.py
@@ -136,6 +136,11 @@ class GPyRegression:
     def update(self, x, y, optimize=False):
         """Updates the GP model with new data
         """
+
+        # Must cast these as 2d for GPy
+        x = x.reshape((-1, self.input_dim))
+        y = y.reshape((-1, 1))
+
         if self._gp is None:
             self._init_gp(x, y)
         else:

--- a/elfi/methods/methods.py
+++ b/elfi/methods/methods.py
@@ -452,10 +452,10 @@ class Rejection(InferenceMethod):
     def _init_state_samples(self, batch):
         # Initialize the outputs dict based on the received batch
         samples = {}
-        for output in self.outputs:
+        for node in self.outputs:
             shape = (self.objective['n_samples'] + self.batch_size,) \
-                    + batch[output].shape[1:]
-            samples[output] = np.ones(shape) * np.inf
+                    + batch[node].shape[1:]
+            samples[node] = np.ones(shape) * np.inf
         self.state['samples'] = samples
 
     def _merge_batch(self, batch):
@@ -465,8 +465,8 @@ class Rejection(InferenceMethod):
         samples = self.state['samples']
 
         # Put the acquired samples to the end
-        for k, v in samples.items():
-            v[self.objective['n_samples']:] = batch[k]
+        for node, v in samples.items():
+            v[self.objective['n_samples']:] = batch[node]
 
         # Sort the smallest to the beginning
         sort_mask = np.argsort(samples[self.discrepancy], axis=0).ravel()

--- a/elfi/model/elfi_model.py
+++ b/elfi/model/elfi_model.py
@@ -343,15 +343,15 @@ class ObservableMixin(NodeReference):
 
 
 class ScipyLikeRV(StochasticMixin, NodeReference):
-    def __init__(self, distribution="uniform", *params, size=1, **kwargs):
+    def __init__(self, distribution="uniform", *params, size=None, **kwargs):
         """
 
         Parameters
         ----------
         distribution : str or scipy-like distribution object
         params : params of the distribution
-        size : int, tuple or None
-            size of a single random draw. None means a scalar.
+        size : int, tuple or None, optional
+            size of a single random draw. None (default) means a scalar.
 
         """
 

--- a/examples/ma2.py
+++ b/examples/ma2.py
@@ -8,14 +8,15 @@ from elfi.model.extensions import ScipyLikeDistribution
 """
 
 
-def MA2(t1, t2, n_obs=100, batch_size=1, random_state=None, w=None):
-    if w is None:
-        if random_state is None:
-            # Use the global random_state
-            random_state = np.random
-        w = random_state.randn(batch_size, n_obs+2) # i.i.d. sequence ~ N(0,1)
+def MA2(t1, t2, n_obs=100, batch_size=1, random_state=None):
+    random_state = random_state or np.random
+    # i.i.d. sequence ~ N(0,1)
+    w = random_state.randn(batch_size, n_obs+2)
 
-    w = np.atleast_2d(w)
+    # Make inputs 2d arrays for broadcasting with w
+    t1 = np.atleast_2d(t1).reshape((-1, 1))
+    t2 = np.atleast_2d(t2).reshape((-1, 1))
+
     x = w[:, 2:] + t1*w[:, 1:-1] + t2*w[:, :-2]
     return x
 
@@ -24,12 +25,12 @@ def autocov(x, lag=1):
     """Autocovariance assuming a (weak) univariate stationary process with mean 0.
     Realizations are in rows.
     """
-    C = np.mean(x[:, lag:]*x[:, :-lag], axis=1, keepdims=True)
+    C = np.mean(x[:, lag:]*x[:, :-lag], axis=1)
     return C
 
 
 def discrepancy(x, y):
-    d = np.linalg.norm(np.array(x) - np.array(y), ord=2, axis=0)
+    d = np.linalg.norm(np.column_stack(x) - np.column_stack(y), ord=2, axis=1)
     return d
 
 

--- a/tests/unit/test_examples.py
+++ b/tests/unit/test_examples.py
@@ -16,8 +16,7 @@ def test_generate():
     res = d.generate(n_gen)
 
     assert res.shape[0] == n_gen
-    assert res.ndim == 2
-    assert res.shape[1] == 1
+    assert res.ndim == 1
 
 
 @pytest.mark.usefixtures('with_all_clients')


### PR DESCRIPTION
All outputs are required to be arrays. Make the default output of `Prior` a 1d vector. Do not require any longer that all vectors need to be at least 2d. Strip away unnecessary dimensions if possible to follow numpy convention.