### PR TITLE
Support for batch_index parameter to nodes

### DIFF
--- a/elfi/client.py
+++ b/elfi/client.py
@@ -5,9 +5,9 @@ from collections import OrderedDict
 import networkx as nx
 
 from elfi.executor import Executor
-from elfi.compiler import OutputCompiler, ObservedCompiler, BatchSizeCompiler, \
+from elfi.compiler import OutputCompiler, ObservedCompiler, BatchMetaCompiler, \
     ReduceCompiler, RandomStateCompiler
-from elfi.loader import ObservedLoader, BatchSizeLoader, RandomStateLoader, PoolLoader
+from elfi.loader import ObservedLoader, BatchMetaLoader, RandomStateLoader, PoolLoader
 
 logger = logging.getLogger(__name__)
 
@@ -177,12 +177,14 @@ class ClientBase:
         """
         if outputs is None:
             outputs = source_net.nodes()
+        if not outputs:
+            logger.warning("Compiling for no outputs!")
         outputs = outputs if isinstance(outputs, list) else [outputs]
         compiled_net = nx.DiGraph(outputs=outputs)
 
         compiled_net = OutputCompiler.compile(source_net, compiled_net)
         compiled_net = ObservedCompiler.compile(source_net, compiled_net)
-        compiled_net = BatchSizeCompiler.compile(source_net, compiled_net)
+        compiled_net = BatchMetaCompiler.compile(source_net, compiled_net)
         compiled_net = RandomStateCompiler.compile(source_net, compiled_net)
         compiled_net = ReduceCompiler.compile(source_net, compiled_net)
 
@@ -207,7 +209,7 @@ class ClientBase:
         loaded_net = nx.DiGraph(compiled_net)
 
         loaded_net = ObservedLoader.load(context, loaded_net, batch_index)
-        loaded_net = BatchSizeLoader.load(context, loaded_net, batch_index)
+        loaded_net = BatchMetaLoader.load(context, loaded_net, batch_index)
         loaded_net = RandomStateLoader.load(context, loaded_net, batch_index)
         loaded_net = PoolLoader.load(context, loaded_net, batch_index)
 

--- a/elfi/compiler.py
+++ b/elfi/compiler.py
@@ -116,17 +116,21 @@ class ObservedCompiler(Compiler):
         return obs_node
 
 
-class BatchSizeCompiler(Compiler):
+class BatchMetaCompiler(Compiler):
     @classmethod
     def compile(cls, source_net, compiled_net):
         logger.debug("{} compiling...".format(cls.__name__))
 
-        _node = '_batch_size'
-        for node, d in source_net.nodes_iter(data=True):
-            if d.get('_uses_batch_size'):
-                if not compiled_net.has_node(_node):
-                    compiled_net.add_node(_node)
-                compiled_net.add_edge(_node, node, param='batch_size')
+        instruction_node_map = dict(_uses_batch_size='_batch_size',
+                                    _uses_batch_index='_batch_index')
+
+        for instruction, _node in instruction_node_map.items():
+            for node, d in source_net.nodes_iter(data=True):
+                if d.get(instruction):
+                    if not compiled_net.has_node(_node):
+                        compiled_net.add_node(_node)
+                    compiled_net.add_edge(_node, node, param=_node[1:])
+
         return compiled_net
 
 

--- a/elfi/loader.py
+++ b/elfi/loader.py
@@ -39,16 +39,18 @@ class ObservedLoader(Loader):
         return output_net
 
 
-class BatchSizeLoader(Loader):
-    """
-    Add observed data to computation graph
+class BatchMetaLoader(Loader):
+    """Adds values to _batch_size and _batch_index nodes if they are present.
     """
 
     @classmethod
     def load(cls, context, output_net, batch_index):
-        _name = '_batch_size'
-        if output_net.has_node(_name):
-            output_net.node[_name]['output'] = context.batch_size
+        details = dict(_batch_size=context.batch_size,
+                       _batch_index=batch_index)
+
+        for node, v in details.items():
+            if output_net.has_node(node):
+                output_net.node[node]['output'] = v
 
         return output_net
 

--- a/tests/functional/test_compilation.py
+++ b/tests/functional/test_compilation.py
@@ -1,0 +1,48 @@
+import pytest
+
+import ipyparallel
+
+import elfi
+
+
+@pytest.mark.usefixtures('with_all_clients')
+def test_batch_index_param(ma2):
+    sim = ma2.get_reference('MA2')
+
+    # Test that it is passed
+    try:
+        # Add to state
+        sim['_uses_batch_index'] = True
+        sim.generate()
+        assert False, "Should raise an error"
+    except TypeError:
+        assert True
+    except ipyparallel.error.RemoteError:
+        assert True
+
+
+# TODO: add ipyparallel, maybe use dill or cloudpickle
+# client.ipp_client[:].use_dill() or .use_cloudpickle()
+def test_batch_index_value(ma2):
+    bi = lambda batch_index : batch_index
+
+    # Test the correct batch_index value
+    m = elfi.ElfiModel()
+    op = elfi.Operation(bi, model=m, name='op')
+    op['_uses_batch_index'] = True
+    client = elfi.get_client()
+    c = elfi.ComputationContext()
+    compiled_net = client.compile(m.source_net, m.nodes)
+    loaded_net = client.load_data(compiled_net, c, batch_index=3)
+    res = client.compute(loaded_net)
+
+    assert res['op'] == 3
+
+
+def test_reduce_compiler(ma2, client):
+    compiled_net = client.compile(ma2.source_net)
+    assert compiled_net.has_node('S1')
+
+    compiled_net2 = client.compile(ma2.source_net, ['MA2'])
+    assert not compiled_net2.has_node('S1')
+

--- a/tests/functional/test_serialization.py
+++ b/tests/functional/test_serialization.py
@@ -1,8 +1,7 @@
-import pytest
+
 import pickle
 
 import numpy as np
-import scipy.stats as ss
 
 from elfi.client import ClientBase
 from elfi.executor import Executor

--- a/tests/unit/test_elfi_model.py
+++ b/tests/unit/test_elfi_model.py
@@ -1,7 +1,6 @@
 import pytest
 
 import numpy as np
-import scipy.stats as ss
 
 import elfi.model.elfi_model as em
 import examples.ma2 as ma2
@@ -37,11 +36,13 @@ def test_observed():
 def test_node_reference_str():
     # This is important because it is used when passing NodeReferences as InferenceMethod
     # arguments
+    em.reset_current_model()
     ref = em.NodeReference(name='test')
     assert str(ref) == 'test'
 
 
 def test_name_determination():
+    em.reset_current_model()
     node = em.NodeReference()
     assert node.name == 'node'
 


### PR DESCRIPTION
Allows node to receive the `batch_index` as a parameter for the node operation.

Example
------------
```
sim = elfi.Simulator(...)
sim['_uses_batch_index'] = True
```