### PR TITLE
Raise AttributeError when non-existent item requested, add tests

### DIFF
--- a/elfi/results/result.py
+++ b/elfi/results/result.py
@@ -49,6 +49,8 @@ class Result(object):
             return self.item
         elif item in self.meta.keys():
             return self.meta[item]
+        else:
+            raise AttributeError("No attribute '{}' in this Result".format(item))
 
     def __dir__(self):
         """Allows autocompletion for items under self.meta.

--- a/tests/unit/test_results.py
+++ b/tests/unit/test_results.py
@@ -1,0 +1,35 @@
+import pytest
+import logging
+
+import numpy as np
+
+from elfi.results.result import Result
+
+
+def test_result_obj():
+    n_samples = 10
+    parameter_names = ['a', 'b']
+    distance_name = 'dist'
+    samples = [np.empty(n_samples), np.empty(n_samples), np.empty(n_samples)]
+    outputs = dict(zip(parameter_names + [distance_name], samples))
+    result = Result(method_name="TestRes",
+                    outputs=outputs,
+                    parameter_names=parameter_names,
+                    discrepancy_name=distance_name,
+                    something='x',
+                    something_else='y'
+                    )
+
+    assert result.method_name == "TestRes"
+    assert hasattr(result, 'samples')
+    assert result.n_samples == n_samples
+    assert result.n_params == len(parameter_names)
+
+    assert np.allclose(samples[:-1], result.samples_list)
+    assert np.allclose(samples[-1], result.discrepancy)
+
+    assert hasattr(result, 'something')
+    assert result.something_else == 'y'
+
+    with pytest.raises(AttributeError):
+        result.not_here


### PR DESCRIPTION
Result object raises KeyError when non-existent item requested
Add some tests for Result