### PR TITLE
Add a class for univariate empirical densities

### DIFF
--- a/elfi/methods/empirical_density.py
+++ b/elfi/methods/empirical_density.py
@@ -1,0 +1,101 @@
+import numpy as np
+import scipy.stats as ss
+import scipy.optimize as opt
+
+
+class EmpiricalDensity(object):
+    """A wrapper for a Gaussian kernel density estimate.
+    
+    Parameters
+    ----------
+    samples : np.ndarray
+        a univariate sample
+
+    Attributes
+    ----------
+    kde :
+        a Gaussian kernel density estimate
+    support : tuple
+        an approximate support for the empirical distribution
+    """
+
+    def __init__(self, samples, **kwargs):
+        self.kde = ss.gaussian_kde(samples, **kwargs)
+        # Try cover the support of the pdf
+        # TODO: Use the kde
+        a, b = (min(samples), max(samples))
+        extension = (b - a)*0.5
+        self.support = (a - extension, b + extension)
+        # self.pdf.__doc__ = self.kde.pdf.__doc__
+        # self.logpdf.__doc__ = self.kde.logpdf.__doc__
+
+    @property
+    def dataset(self):
+        return self.kde.dataset
+    
+    @property
+    def n(self):
+        return self.kde.n
+        
+    def pdf(self, x):
+        return self.kde.pdf(x)
+
+    def logpdf(self, x):
+        return self.kde.logpdf(x)
+
+    def _cdf(self, x):
+        return self.kde.integrate_box_1d(-np.inf, x)
+
+    def cdf(self, x):
+        """Cumulative distribution function of the empirical distribution.
+
+        Parameters
+        ----------
+        x : array_like
+            quantiles
+        """
+        if isinstance(x, np.ndarray):
+            return np.array([self._cdf(xi) for xi in x.flat])
+        else:
+            return self._cdf(x)
+
+    def _ppf(self, q):
+        return opt.brentq(lambda x: self._cdf(x) - q, *self.support)
+
+    def ppf(self, q):
+        """Percent point function (inverse of `cdf`) at q
+        of the empirical distribution.
+
+        Parameters
+        ----------
+        q : array_like
+            lower tail probability
+        """
+        if isinstance(q, np.ndarray):
+            return np.array([self._ppf(qi) for qi in q.flat])
+        else:
+            return self._ppf(q)
+
+    def rvs(self, n):
+        """Sample n values from the empirical density."""
+        u = np.random.rand(n)
+        return self.ppf(u)
+
+
+def estimate_densities(marginal_samples, **kwargs):
+    """Compute Gaussian kernel density estimates.
+
+    Parameters
+    ----------
+    marginal_samples : np.ndarray
+        a NxM array of N observations in M variables
+    **kwargs :
+        additional arguments
+    
+    Returns
+    -------
+    empirical_densities : 
+       a list of EmpiricalDensity objects
+    """
+    return [EmpiricalDensity(marginal_samples[:, i], **kwargs)
+            for i in range(marginal_samples.shape[1])]

--- a/tests/functional/test_empirical_density.py
+++ b/tests/functional/test_empirical_density.py
@@ -1,0 +1,15 @@
+import numpy as np
+import scipy.stats as ss
+
+import elfi.methods.empirical_density as ed
+
+std = 5
+mu = 10
+nobs = 10000
+N = ss.norm(loc=mu, scale=std)
+X = N.rvs(size=nobs)
+emp = ed.EmpiricalDensity(X)
+t = np.linspace(*emp.support, 100)
+
+def test_empirical_cdf():
+    assert np.allclose(N.cdf(t), emp.cdf(t), atol=1e-2)


### PR DESCRIPTION
#### Summary:
This is a wrapper for the Gaussian KDE from scipy. It adds methods for the cumulative distribution function and the quantile function.

There might be numerical issues near zero and one for the quantile function (ppf). I suspect these have to do with the support of the pdf. There should probably be a cutoffs at the tails.

#### How to Verify:
I wasn't sure how to test this. Suggestions are welcome.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD3 (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
