### PR TITLE
Unsigned int32 doesn't seem to work in Windows 10: changed to signed

### DIFF
--- a/elfi/utils.py
+++ b/elfi/utils.py
@@ -36,7 +36,7 @@ def nbunch_ancestors(G, nbunch):
     return ancestors
 
 
-def get_sub_seed(random_state, sub_seed_index, high=2**32):
+def get_sub_seed(random_state, sub_seed_index, high=2**31):
     """Returns a sub seed. The returned sub seed is unique for its index, i.e. no
     two indexes can return the same sub_seed. Same random_state will also always
     produce the same sequence.


### PR DESCRIPTION
Tested ELFI dev (and bolfi_seed)  in Windows 10:

- tests: native + ipyparallel
- notebooks: tutorial + parallelization
- too much hazzle now to set up the system for the external operations

Everything works fine after this small change.