### PR TITLE
Add linear regression adjustment

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -61,11 +61,9 @@ Below is a list of inference methods included in ELFI.
 
 **Post-processing**
 
-.. currentmodule:: elfi.methods.post_processing
-
 .. autosummary::
-   LinearAdjustment
-   adjust_posterior
+   elfi.adjust_posterior
+   elfi.methods.post_processing.LinearAdjustment
 
 Other
 -----

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -59,6 +59,14 @@ Below is a list of inference methods included in ELFI.
    SmcSample
    BolfiSample
 
+**Post-processing**
+
+.. currentmodule:: elfi.methods.post_processing
+
+.. autosummary::
+   LinearAdjustment
+   adjust_posterior
+
 Other
 -----
 
@@ -179,6 +187,16 @@ Inference API classes
    :inherited-members:
 
 .. autoclass:: BolfiSample
+   :members:
+   :inherited-members:
+
+.. currentmodule:: elfi.methods.post_processing
+
+.. autoclass:: RegressionAdjustment
+   :members:
+   :inherited-members:
+
+.. autoclass:: LinearAdjustment
    :members:
    :inherited-members:
 

--- a/elfi/__init__.py
+++ b/elfi/__init__.py
@@ -6,7 +6,7 @@ import elfi.methods.mcmc
 import elfi.model.tools as tools
 from elfi.client import get_client, set_client
 from elfi.methods.parameter_inference import *
-from elfi.methods.post_processing import *
+from elfi.methods.post_processing import adjust_posterior
 from elfi.model.elfi_model import *
 from elfi.model.extensions import ScipyLikeDistribution as Distribution
 from elfi.store import OutputPool, ArrayPool

--- a/elfi/__init__.py
+++ b/elfi/__init__.py
@@ -6,6 +6,7 @@ import elfi.methods.mcmc
 import elfi.model.tools as tools
 from elfi.client import get_client, set_client
 from elfi.methods.parameter_inference import *
+from elfi.methods.post_processing import *
 from elfi.model.elfi_model import *
 from elfi.model.extensions import ScipyLikeDistribution as Distribution
 from elfi.store import OutputPool, ArrayPool

--- a/elfi/methods/post_processing.py
+++ b/elfi/methods/post_processing.py
@@ -55,7 +55,7 @@ class RegressionAdjustment(object):
         if not self._fitted:
             raise ValueError("The regression model must be fitted first. Use the fit() method.")
 
-    def fit(self, model, result, summary_names, parameter_names):
+    def fit(self, model, result, parameter_names, summary_names):
         """Fit a regression adjustment model to the posterior result.
 
         Parameters
@@ -121,3 +121,10 @@ def _response(result, parameter_names):
     """An iterator for parameter values."""
     for name in parameter_names:
         yield result.outputs[name]
+
+
+def adjust_posterior(model, result, parameter_names, summary_names, adjustment=LinearAdjustment()):
+    """Adjust the posterior using local regression."""
+    adjustment.fit(model, result, parameter_names, summary_names)
+    return adjustment.adjust()
+

--- a/elfi/methods/post_processing.py
+++ b/elfi/methods/post_processing.py
@@ -44,8 +44,6 @@ class RegressionAdjustment(object):
       a list of fitted regression model instances
     parameter_names
       a list of parameter names
-    parameters
-      a generator for the values of the parameters
     sample
       the sample object from an ABC algorithm
     X
@@ -224,7 +222,7 @@ def adjust_posterior(model, sample, summary_names,
     ----------
     model : elfi.ElfiModel
       the inference model
-    sample : elfi.
+    sample : elfi.methods.results.Sample
       a sample object from an ABC algorithm
     parameter_names : list[str] (optional)
       names of the parameters

--- a/elfi/methods/post_processing.py
+++ b/elfi/methods/post_processing.py
@@ -68,13 +68,11 @@ class RegressionAdjustment(object):
 
     @property
     def sample(self):
-        """Sample object"""
         self._check_fitted()
         return self._sample
 
     @property
     def X(self):
-        """The input variables"""
         self._check_fitted()
         return self._X
 
@@ -83,7 +81,7 @@ class RegressionAdjustment(object):
             raise ValueError("The regression model must be fitted first. "
                              "Use the fit() method.")
 
-    def fit(self, model, sample, summary_names, parameter_names=None):
+    def fit(self, sample, model, summary_names, parameter_names=None):
         """Fit a regression adjustment model to the posterior sample.
 
         Non-finite values in the summary statistics and parameters
@@ -91,14 +89,14 @@ class RegressionAdjustment(object):
 
         Parameters
         ----------
-        model : elfi.ElfiModel
-          the inference model
         sample : elfi.methods.Sample
           a sample object from an ABC method
-        parameter_names : list[str] (optional)
-          a list of parameter names
+        model : elfi.ElfiModel
+          the inference model
         summary_names : list[str]
           a list of names for the summary nodes
+        parameter_names : list[str] (optional)
+          a list of parameter names
         """
         self._X = self._input_variables(model, sample, summary_names)
         self._sample = sample
@@ -210,7 +208,7 @@ class LinearAdjustment(RegressionAdjustment):
         return summaries - observed_summaries
 
 
-def adjust_posterior(model, sample, summary_names,
+def adjust_posterior(sample, model, summary_names,
                      parameter_names=None, adjustment='linear'):
     """Adjust the posterior using local regression.
 
@@ -220,14 +218,14 @@ def adjust_posterior(model, sample, summary_names,
 
     Parameters
     ----------
-    model : elfi.ElfiModel
-      the inference model
     sample : elfi.methods.results.Sample
       a sample object from an ABC algorithm
-    parameter_names : list[str] (optional)
-      names of the parameters
+    model : elfi.ElfiModel
+      the inference model
     summary_names : list[str]
       names of the summary nodes
+    parameter_names : list[str] (optional)
+      names of the parameters
     adjustment : RegressionAdjustment or string
       a regression adjustment object or a string specification
 
@@ -246,7 +244,7 @@ def adjust_posterior(model, sample, summary_names,
     >>> from elfi.examples import gauss
     >>> m = gauss.get_model()
     >>> res = elfi.Rejection(m['d'], output_names=['S1', 'S2']).sample(1000)
-    >>> adj = adjust_posterior(m, res, ['S1', 'S2'], ['mu'], LinearAdjustment())
+    >>> adj = adjust_posterior(res, m, ['S1', 'S2'], ['mu'], LinearAdjustment())
     """
     adjustment = _get_adjustment(adjustment)
     adjustment.fit(model=model, sample=sample,

--- a/elfi/methods/post_processing.py
+++ b/elfi/methods/post_processing.py
@@ -1,0 +1,87 @@
+"""
+Post-processing
+"""
+
+import numpy as np
+from sklearn.linear_model import LinearRegression
+
+
+class RegressionAdjustment(object):
+    def __init__(self, **kwargs):
+        self._model_kwargs = kwargs
+        self._fitted = False
+        self.regression_models =[]
+
+    @property
+    def parameter_names(self):
+        self._check_fitted()
+        return self._parameter_names
+
+    @property
+    def parameters(self):
+        self._check_fitted()
+        
+        def iterator():
+            for name in self.parameter_names:
+                yield self.result.outputs[name]
+
+        return iterator()
+
+    @property
+    def result(self):
+        self._check_fitted()
+        return self._result
+
+    @property
+    def X(self):
+        self._check_fitted()
+        return self._X
+
+    def _check_fitted(self):
+        if not self._fitted:
+            raise ValueError("The regression model must be fitted first. Use the fit() method.")
+
+    def fit(self, result, summary_names, observed_summaries, parameter_names):
+        self._X = _input_variables(result, observed_summaries, summary_names)
+        self._result = result
+        self._parameter_names = parameter_names
+        for r in _response(result, parameter_names):
+            self.regression_models.append(self._fit1(self._X, r))
+
+        self._fitted = True
+
+    def _fit1(self, X, y):
+        return self._regression_model(**self._model_kwargs).fit(X, y)
+
+    def adjust(self):
+        adjusted_theta = []
+        for (i, theta_i) in enumerate(self.parameters):
+            adjusted_theta.append(self._adjust1(theta_i, self.regression_models[i]))
+
+        return np.stack(adjusted_theta, axis=1)
+
+    def _adjust1(self, theta_i, regression_model):
+        raise NotImplementedError
+
+
+class LinearAdjustment(RegressionAdjustment):
+    _regression_model = LinearRegression
+
+    def __init__(self, **kwargs):
+        super(LinearAdjustment, self).__init__(**kwargs)
+
+    def _adjust1(self, theta_i, regression_model):
+        b = regression_model.coef_
+        return theta_i - self.X.dot(b)
+        
+
+def _input_variables(result, observed_summaries, summary_names):
+    """Construct a matrix of input variables from summaries."""
+    summaries = np.stack([result.outputs[name] for name in summary_names], axis=1)
+    return summaries - observed_summaries
+
+
+def _response(result, parameter_names):
+    for name in parameter_names:
+        yield result.outputs[name]
+

--- a/elfi/methods/post_processing.py
+++ b/elfi/methods/post_processing.py
@@ -25,13 +25,13 @@ class RegressionAdjustment(object):
     Each parameter is assumed to be a scalar. A local regression is
     fitted for each parameter individually using the values of the
     summary statistics as the regressors.  The regression model can be
-    any object implementing a 'fit()' method. All keyword arguments
+    any object implementing a `fit()` method. All keyword arguments
     given to the constructor are passed to the regression model.
 
-    Subclasses need to implement the methods '_adjust' and
-    '_input_variables'.  They must also specify the class variables
-    '_regression_model' and '_name'.  See the individual documentation
-    and the 'LinearAdjustment' class for further detail.
+    Subclasses need to implement the methods `_adjust` and
+    `_input_variables`.  They must also specify the class variables
+    `_regression_model` and `_name`.  See the individual documentation
+    and the `LinearAdjustment` class for further detail.
 
     Parameters
     ----------
@@ -213,7 +213,7 @@ def adjust_posterior(sample, model, summary_names,
     """Adjust the posterior using local regression.
 
     Note that the summary nodes need to be explicitly included to the
-    sample object with the 'output_names' keyword argument when performing
+    sample object with the `output_names` keyword argument when performing
     the inference.
 
     Parameters

--- a/elfi/methods/post_processing.py
+++ b/elfi/methods/post_processing.py
@@ -14,6 +14,7 @@ __all__ = ('LinearAdjustment', 'adjust_posterior')
 class RegressionAdjustment(object):
     """Base class for regression adjustments."""
     _regression_model = None
+    _name = 'RegressionAdjustment'
 
     def __init__(self, **kwargs):
         self._model_kwargs = kwargs
@@ -87,12 +88,15 @@ class RegressionAdjustment(object):
         -------
           a numpy array with the adjusted posterior sample
         """
-        #TODO: return a Result object
-        adjusted_theta = []
-        for (i, theta_i) in enumerate(self.parameters):
-            adjusted_theta.append(self._adjust1(theta_i, self.regression_models[i]))
+        outputs = {}
+        for (i, name) in enumerate(self.parameter_names):
+            theta_i = self.result.outputs[name]
+            adjusted = self._adjust1(theta_i, self.regression_models[i])
+            outputs[name] = adjusted
 
-        return np.stack(adjusted_theta, axis=1)
+        res = results.Result(method_name=self._name, outputs=outputs,
+                             parameter_names=self._parameter_names)
+        return res
 
     def _adjust1(self, theta_i, regression_model):
         raise NotImplementedError
@@ -101,6 +105,7 @@ class RegressionAdjustment(object):
 class LinearAdjustment(RegressionAdjustment):
     """Regression adjustment using a local linear model."""
     _regression_model = LinearRegression
+    _name = 'LinearAdjustment'
 
     def __init__(self, **kwargs):
         super(LinearAdjustment, self).__init__(**kwargs)

--- a/elfi/methods/post_processing.py
+++ b/elfi/methods/post_processing.py
@@ -2,15 +2,21 @@
 Post-processing
 """
 
-import numpy as np
 from sklearn.linear_model import LinearRegression
+import numpy as np
 
 
 class RegressionAdjustment(object):
+    """Base class for regression adjustments."""
+    _regression_model = None
+
     def __init__(self, **kwargs):
         self._model_kwargs = kwargs
         self._fitted = False
         self.regression_models =[]
+        self._X = None
+        self._result = None
+        self._parameter_names = None
 
     @property
     def parameter_names(self):
@@ -19,6 +25,7 @@ class RegressionAdjustment(object):
 
     @property
     def parameters(self):
+        """Iterator for parameter values"""
         self._check_fitted()
         
         def iterator():
@@ -29,11 +36,13 @@ class RegressionAdjustment(object):
 
     @property
     def result(self):
+        """Result object"""
         self._check_fitted()
         return self._result
 
     @property
     def X(self):
+        """The input variables"""
         self._check_fitted()
         return self._X
 
@@ -42,6 +51,19 @@ class RegressionAdjustment(object):
             raise ValueError("The regression model must be fitted first. Use the fit() method.")
 
     def fit(self, result, summary_names, observed_summaries, parameter_names):
+        """Fit a regression adjustment model to the posterior result.
+
+        Parameters
+        ----------
+        result : elfi.methods.Result
+          a result object from an ABC method
+        summary_names : list[str]
+          a list of names for the summary nodes
+        observed_summaries : array_like
+          an array of summary statistics for the observed values
+        parameter_names : list[str]
+          a list of parameter names
+        """
         self._X = _input_variables(result, observed_summaries, summary_names)
         self._result = result
         self._parameter_names = parameter_names
@@ -54,6 +76,12 @@ class RegressionAdjustment(object):
         return self._regression_model(**self._model_kwargs).fit(X, y)
 
     def adjust(self):
+        """Adjust the posterior.
+
+        Returns
+        -------
+          a numpy array with the adjusted posterior sample
+        """
         adjusted_theta = []
         for (i, theta_i) in enumerate(self.parameters):
             adjusted_theta.append(self._adjust1(theta_i, self.regression_models[i]))
@@ -65,6 +93,7 @@ class RegressionAdjustment(object):
 
 
 class LinearAdjustment(RegressionAdjustment):
+    """Regression adjustment using a local linear model."""
     _regression_model = LinearRegression
 
     def __init__(self, **kwargs):
@@ -82,6 +111,7 @@ def _input_variables(result, observed_summaries, summary_names):
 
 
 def _response(result, parameter_names):
+    """An iterator for parameter values."""
     for name in parameter_names:
         yield result.outputs[name]
 

--- a/elfi/methods/post_processing.py
+++ b/elfi/methods/post_processing.py
@@ -85,7 +85,7 @@ class RegressionAdjustment(object):
             raise ValueError("The regression model must be fitted first. "
                              "Use the fit() method.")
 
-    def fit(self, model, sample, parameter_names, summary_names):
+    def fit(self, model, sample, summary_names, parameter_names=None):
         """Fit a regression adjustment model to the posterior sample.
 
         Non-finite values in the summary statistics and parameters
@@ -97,14 +97,14 @@ class RegressionAdjustment(object):
           the inference model
         sample : elfi.methods.Sample
           a sample object from an ABC method
-        parameter_names : list[str]
+        parameter_names : list[str] (optional)
           a list of parameter names
         summary_names : list[str]
           a list of names for the summary nodes
         """
         self._X = self._input_variables(model, sample, summary_names)
         self._sample = sample
-        self._parameter_names = parameter_names
+        self._parameter_names = parameter_names or sample.parameter_names
         self._get_finite()
 
         for pair in self._pairs():
@@ -212,8 +212,8 @@ class LinearAdjustment(RegressionAdjustment):
         return summaries - observed_summaries
 
 
-def adjust_posterior(model, sample, parameter_names,
-                     summary_names, adjustment='linear'):
+def adjust_posterior(model, sample, summary_names,
+                     parameter_names=None, adjustment='linear'):
     """Adjust the posterior using local regression.
 
     Note that the summary nodes need to be explicitly included to the
@@ -226,7 +226,7 @@ def adjust_posterior(model, sample, parameter_names,
       the inference model
     sample : elfi.
       a sample object from an ABC algorithm
-    parameter_names : list[str]
+    parameter_names : list[str] (optional)
       names of the parameters
     summary_names : list[str]
       names of the summary nodes
@@ -251,7 +251,9 @@ def adjust_posterior(model, sample, parameter_names,
     >>> adj = adjust_posterior(m, res, ['mu'], ['S1', 'S2'], LinearAdjustment())
     """
     adjustment = _get_adjustment(adjustment)
-    adjustment.fit(model, sample, parameter_names, summary_names)
+    adjustment.fit(model=model, sample=sample,
+                   parameter_names=parameter_names,
+                   summary_names=summary_names)
     return adjustment.adjust()
 
 

--- a/elfi/methods/post_processing.py
+++ b/elfi/methods/post_processing.py
@@ -223,10 +223,10 @@ def adjust_posterior(model, result, parameter_names, summary_names, adjustment=N
     --------
 
     >>> import elfi
-    >>> from elfi.examples import bdm
-    >>> m = bdm.get_model()
-    >>> res = elfi.Rejection(m['d'], outputs=['T1']).sample(1000)
-    >>> adj = adjust_posterior(m, res, ['alpha'], ['T1'], LinearAdjustment())
+    >>> from elfi.examples import gauss
+    >>> m = gauss.get_model()
+    >>> res = elfi.Rejection(m['d'], outputs=['S1', 'S2']).sample(1000)
+    >>> adj = adjust_posterior(m, res, ['mu'], ['S1', 'S2'], LinearAdjustment())
     """
     adjustment = adjustment or LinearAdjustment()
     adjustment.fit(model, result, parameter_names, summary_names)

--- a/elfi/methods/post_processing.py
+++ b/elfi/methods/post_processing.py
@@ -197,6 +197,7 @@ def adjust_posterior(model, result, parameter_names, summary_names, adjustment=N
     Examples
     --------
 
+    >>> import elfi
     >>> from elfi.examples import bdm
     >>> m = bdm.get_model()
     >>> res = elfi.Rejection(m['d'], outputs=['T1']).sample(1000)

--- a/elfi/methods/post_processing.py
+++ b/elfi/methods/post_processing.py
@@ -1,14 +1,12 @@
 """
-Post-processing for posterior approximations from other ABC algorithms.
+Post-processing for posterior samples from other ABC algorithms.
 
-See the review paper:
-
+References
+----------
 Fundamentals and Recent Developments in Approximate Bayesian Computation
 Lintusaari et. al
 Syst Biol (2017) 66 (1): e66-e82.
 https://doi.org/10.1093/sysbio/syw077
-
-for more information.
 """
 import warnings
 
@@ -90,6 +88,9 @@ class RegressionAdjustment(object):
     def fit(self, model, sample, parameter_names, summary_names):
         """Fit a regression adjustment model to the posterior sample.
 
+        Non-finite values in the summary statistics and parameters
+        will be omitted.
+
         Parameters
         ----------
         model : elfi.ElfiModel
@@ -123,6 +124,9 @@ class RegressionAdjustment(object):
 
     def adjust(self):
         """Adjust the posterior.
+
+        Only the non-finite values used to fit the regression model
+        will be adjusted.
 
         Returns
         -------

--- a/elfi/methods/post_processing.py
+++ b/elfi/methods/post_processing.py
@@ -135,18 +135,20 @@ class RegressionAdjustment(object):
         outputs = {}
         for (i, name) in enumerate(self.parameter_names):
             theta_i = self.sample.outputs[name][self._finite[i]]
-            adjusted = self._adjust(theta_i, self.regression_models[i])
+            adjusted = self._adjust(i, theta_i, self.regression_models[i])
             outputs[name] = adjusted
 
         res = results.Sample(method_name=self._name, outputs=outputs,
                              parameter_names=self._parameter_names)
         return res
 
-    def _adjust(self, theta_i, regression_model):
+    def _adjust(self, i, theta_i, regression_model):
         """Adjust a single parameter using a fitted regression model.
 
         Parameters
         ----------
+        i : int
+          the index of the parameter
         theta_i : np.ndarray
           a vector of parameter values to adjust
         regression_model
@@ -186,7 +188,7 @@ class RegressionAdjustment(object):
         all_finite = all(map(all, finite))
         self._finite = finite
         if not (all(finite_inputs) and all_finite):
-            warning.warn("Non-finite inputs and outputs will be omitted.")
+            warnings.warn("Non-finite inputs and outputs will be omitted.")
 
 
 class LinearAdjustment(RegressionAdjustment):
@@ -197,9 +199,9 @@ class LinearAdjustment(RegressionAdjustment):
     def __init__(self, **kwargs):
         super(LinearAdjustment, self).__init__(**kwargs)
 
-    def _adjust(self, theta_i, regression_model):
+    def _adjust(self, i, theta_i, regression_model):
         b = regression_model.coef_
-        return theta_i - self.X.dot(b)
+        return theta_i - self.X[self._finite[i], :].dot(b)
         
     def _input_variables(self, model, sample, summary_names):
         """Regress on the differences to the observed summaries."""

--- a/elfi/methods/post_processing.py
+++ b/elfi/methods/post_processing.py
@@ -8,7 +8,7 @@ import numpy as np
 from . import results
 
 
-__all__ = ('LinearAdjustment',)
+__all__ = ('LinearAdjustment', 'adjust_posterior')
 
 
 class RegressionAdjustment(object):
@@ -112,7 +112,7 @@ class LinearAdjustment(RegressionAdjustment):
 
 def _input_variables(model, result, summary_names):
     """Construct a matrix of input variables from summaries."""
-    observed_summaries = np.array([model[s].observed for s in summary_names])
+    observed_summaries = np.stack([model[s].observed for s in summary_names], axis=1)
     summaries = np.stack([result.outputs[name] for name in summary_names], axis=1)
     return summaries - observed_summaries
 
@@ -123,8 +123,9 @@ def _response(result, parameter_names):
         yield result.outputs[name]
 
 
-def adjust_posterior(model, result, parameter_names, summary_names, adjustment=LinearAdjustment()):
+def adjust_posterior(model, result, parameter_names, summary_names, adjustment=None):
     """Adjust the posterior using local regression."""
+    adjustment = adjustment or LinearAdjustment()
     adjustment.fit(model, result, parameter_names, summary_names)
     return adjustment.adjust()
 

--- a/elfi/methods/post_processing.py
+++ b/elfi/methods/post_processing.py
@@ -248,7 +248,7 @@ def adjust_posterior(model, sample, summary_names,
     >>> from elfi.examples import gauss
     >>> m = gauss.get_model()
     >>> res = elfi.Rejection(m['d'], output_names=['S1', 'S2']).sample(1000)
-    >>> adj = adjust_posterior(m, res, ['mu'], ['S1', 'S2'], LinearAdjustment())
+    >>> adj = adjust_posterior(m, res, ['S1', 'S2'], ['mu'], LinearAdjustment())
     """
     adjustment = _get_adjustment(adjustment)
     adjustment.fit(model=model, sample=sample,

--- a/elfi/methods/post_processing.py
+++ b/elfi/methods/post_processing.py
@@ -6,6 +6,9 @@ from sklearn.linear_model import LinearRegression
 import numpy as np
 
 
+__all__ = ('LinearAdjustment',)
+
+
 class RegressionAdjustment(object):
     """Base class for regression adjustments."""
     _regression_model = None

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ GPy>=1.0.9
 networkX>=1.11
 ipyparallel>=6
 toolz>=0.8
+scikit-learn>=0.18.1

--- a/tests/functional/test_post_processing.py
+++ b/tests/functional/test_post_processing.py
@@ -1,15 +1,21 @@
 from functools import partial
 
 import numpy as np
+import pytest
 
 import elfi
 from elfi.examples import gauss, ma2
-from elfi import LinearAdjustment
-from elfi.methods.post_processing import adjust_posterior
+from elfi.methods.post_processing import LinearAdjustment, adjust_posterior
+import elfi.methods.post_processing as pp
 
 
 def _statistics(arr):
     return arr.mean(), arr.var()
+
+
+def test_get_adjustment():
+    with pytest.raises(ValueError):
+        pp._get_adjustment('doesnotexist')
 
 
 def test_single_parameter_linear_adjustment():
@@ -40,7 +46,9 @@ def test_single_parameter_linear_adjustment():
 
     res = elfi.Rejection(m['d'], output_names=['S1'],
                          seed=seed).sample(1000, threshold=1)
-    adj = elfi.adjust_posterior(m, res, ['mu'], ['S1'])
+    adj = elfi.adjust_posterior(model=m, sample=res,
+                                parameter_names=['mu'],
+                                summary_names=['S1'])
 
     assert _statistics(adj.outputs['mu']) == (4.9772879640569778, 0.02058680115402544)
 

--- a/tests/functional/test_post_processing.py
+++ b/tests/functional/test_post_processing.py
@@ -22,7 +22,10 @@ def test_single_parameter_linear_adjustment():
     parameter_names = ['alpha']
     linear_adjustment = LinearAdjustment()
 
-    res = elfi.Rejection(m['d'], batch_size=batch_size, seed=seed).sample(n_samples, threshold=threshold)
+    res = elfi.Rejection(m['d'], batch_size=batch_size,
+                         outputs=['T1'],
+                         # outputs=summary_names,
+                         seed=seed).sample(n_samples, threshold=threshold)
     adjusted = adjust_posterior(model=m, result=res,
                                 parameter_names=parameter_names,
                                 summary_names=summary_names,
@@ -45,7 +48,10 @@ def test_multi_parameter_linear_adjustment():
     parameter_names = ['t1', 't2']
     linear_adjustment = LinearAdjustment()
 
-    res = elfi.Rejection(m['d'], batch_size=batch_size, seed=seed).sample(n_samples, threshold=threshold)
+    res = elfi.Rejection(m['d'], batch_size=batch_size,
+                         outputs=['S1', 'S2'],
+                         # outputs=summary_names, # fails ?!?!?
+                         seed=seed).sample(n_samples, threshold=threshold)
     adjusted = adjust_posterior(model=m, result=res,
                                 parameter_names=parameter_names,
                                 summary_names=summary_names,

--- a/tests/functional/test_post_processing.py
+++ b/tests/functional/test_post_processing.py
@@ -38,7 +38,7 @@ def test_single_parameter_linear_adjustment():
     elfi.Summary(lambda x: x.mean(axis=1), m['Gauss'], name='S1')
     elfi.Distance('euclidean', m['S1'], name='d')
 
-    res = elfi.Rejection(m['d'], outputs=['S1'],
+    res = elfi.Rejection(m['d'], output_names=['S1'],
                          seed=seed).sample(1000, threshold=1)
     adj = elfi.adjust_posterior(m, res, ['mu'], ['S1'])
 
@@ -58,10 +58,10 @@ def test_multi_parameter_linear_adjustment():
     linear_adjustment = LinearAdjustment()
 
     res = elfi.Rejection(m['d'], batch_size=batch_size,
-                         outputs=['S1', 'S2'],
-                         # outputs=summary_names, # fails ?!?!?
+                         output_names=['S1', 'S2'],
+                         # output_names=summary_names, # fails ?!?!?
                          seed=seed).sample(n_samples, threshold=threshold)
-    adjusted = adjust_posterior(model=m, result=res,
+    adjusted = adjust_posterior(model=m, sample=res,
                                 parameter_names=parameter_names,
                                 summary_names=summary_names,
                                 adjustment=linear_adjustment)

--- a/tests/functional/test_post_processing.py
+++ b/tests/functional/test_post_processing.py
@@ -1,0 +1,59 @@
+import numpy as np
+
+import elfi
+from elfi.examples import bdm, ma2
+from elfi import LinearAdjustment
+from elfi.methods.post_processing import adjust_posterior
+
+
+def _statistics(arr):
+    return arr.mean(), arr.var()
+
+
+def test_single_parameter_linear_adjustment():
+    """A regression test against values obtained in the notebook."""
+    m = bdm.get_model(alpha=0.2, delta=0, tau=0.198, N=20, seed_obs=None)
+    seed = 20170511
+    threshold = 0.2
+    batch_size = 1000
+    n_samples = 500
+
+    summary_names = ['T1']
+    parameter_names = ['alpha']
+    linear_adjustment = LinearAdjustment()
+
+    res = elfi.Rejection(m['d'], batch_size=batch_size, seed=seed).sample(n_samples, threshold=threshold)
+    adjusted = adjust_posterior(model=m, result=res,
+                                parameter_names=parameter_names,
+                                summary_names=summary_names,
+                                adjustment=linear_adjustment)
+    alpha = adjusted.outputs['alpha']
+
+    ref_mean, ref_var = (0.35199354166477109, 0.034264439593055904)
+    assert _statistics(alpha) == (ref_mean, ref_var)
+
+
+def test_multi_parameter_linear_adjustment():
+    """A regression test against values obtained in the notebook."""
+    seed = 20170511
+    threshold = 0.2
+    batch_size = 1000
+    n_samples = 500
+    m = ma2.get_model(true_params=[0.6, 0.2], seed_obs=seed)
+
+    summary_names = ['S1', 'S2']
+    parameter_names = ['t1', 't2']
+    linear_adjustment = LinearAdjustment()
+
+    res = elfi.Rejection(m['d'], batch_size=batch_size, seed=seed).sample(n_samples, threshold=threshold)
+    adjusted = adjust_posterior(model=m, result=res,
+                                parameter_names=parameter_names,
+                                summary_names=summary_names,
+                                adjustment=linear_adjustment)
+    t1 = adjusted.outputs['t1']
+    t2 = adjusted.outputs['t2']
+
+    t1_mean, t1_var = (0.51606048286584782, 0.017253007645871756)
+    t2_mean, t2_var = (0.15805189695581101, 0.028004406914362647)
+    assert _statistics(t1) == (t1_mean, t1_var)
+    assert _statistics(t2) == (t2_mean, t2_var)


### PR DESCRIPTION
#### Summary:
Adds post processing for results obtained from other ABC algorithms.

#### How to Verify:
I added two regression test that check the results are the same as
[here](https://github.com/kskyten/elfi-notebooks/blob/regression_adjustment/ELFI_regression_adjustment.ipynb). The tests pass locally, but I'm not sure how to get them working on travis as they depend on the bdm binary in the examples.

#### Successful inference in current Notebook examples:
See this [notebook](https://github.com/kskyten/elfi-notebooks/blob/regression_adjustment/ELFI_regression_adjustment.ipynb).
