### PR TITLE
Make initial samples requirement a recommendation instead

### DIFF
--- a/elfi/methods/parameter_inference.py
+++ b/elfi/methods/parameter_inference.py
@@ -753,8 +753,8 @@ class BayesianOptimization(ParameterInference):
             model.parameters.
             `{'parameter_name':(lower, upper), ... }`
         initial_evidence : int, dict, optional
-            Number of initial evidence or a precomputed batch dict containing parameter 
-            and discrepancy values
+            Number of initial evidence or a precomputed batch dict containing parameter
+            and discrepancy values. Defaults to max(10, 2**model_input_dim + 1).
         update_interval : int
             How often to update the GP hyperparameters of the target_model
         exploration_rate : float
@@ -787,8 +787,11 @@ class BayesianOptimization(ParameterInference):
             initial_evidence = len(params)
             self._n_precomputed = initial_evidence
 
+        if initial_evidence < 0:
+            raise ValueError('Number of initial evidence must be positive or zero (was {})'.format(initial_evidence))
         if initial_evidence < n_initial_required:
-            raise ValueError('Need at least {} initialization points'.format(n_initial_required))
+            logger.warning('BOLFI should have at least {} initialization points for reliable initialization (now {})'\
+                           .format(n_initial_required, initial_evidence))
 
         if initial_evidence % self.batch_size != 0:
             raise ValueError('Number of initial evidence must be divisible by the batch size')

--- a/tests/unit/test_bo.py
+++ b/tests/unit/test_bo.py
@@ -40,6 +40,23 @@ def test_BO(ma2):
 
     assert np.array_equal(bo.target_model._gp.X[:n_init, 0], res_init.samples_list[0])
 
+@pytest.mark.usefixtures('with_all_clients')
+def test_BO_works_with_zero_init_samples(ma2):
+    log_d = elfi.Operation(np.log, ma2['d'], name='log_d')
+    bounds = {n:(-2, 2) for n in ma2.parameter_names}
+    bo = elfi.BayesianOptimization(log_d, initial_evidence=0,
+                                   update_interval=4, batch_size=2,
+                                   bounds=bounds)
+    assert bo.target_model.n_evidence == 0
+    assert bo.n_evidence == 0
+    assert bo._n_precomputed == 0
+    assert bo.n_initial_evidence == 0
+    samples = 4
+    bo.infer(samples)
+    assert bo.target_model.n_evidence == samples
+    assert bo.n_evidence == samples
+    assert bo._n_precomputed == 0
+    assert bo.n_initial_evidence == 0
 
 def test_acquisition():
     n_params = 2


### PR DESCRIPTION
Previously BOLFI required a certain number of initial samples
to be computed. As this is not a strict functional requirement,
remove this strict restriction and make it a recommendation instead.
User will receive a warning if the number of initial samples is
not large enough based on initial analysis of the situation.
