### PR TITLE
Bounds must be given as dict for BO/BOLFI

### DIFF
--- a/elfi/methods/parameter_inference.py
+++ b/elfi/methods/parameter_inference.py
@@ -745,12 +745,12 @@ class BayesianOptimization(ParameterInference):
         target_model : GPyRegression, optional
         acquisition_method : Acquisition, optional
             Method of acquiring evidence points. Defaults to LCBSC.
-        acq_noise_cov : float, or np.array of shape (n_params, n_params), optional
+        acq_noise_cov : float, or np.array of shape (n_params,) or np.array of shape (n_params, n_params), optional
             Covariance of the noise added in the default LCBSC acquisition method.
-        bounds : list
+        bounds : dict
             The region where to estimate the posterior for each parameter in
             model.parameters.
-            `[(lower, upper), ... ]`
+            `{'t1':(lower, upper), ... }`
         initial_evidence : int, dict, optional
             Number of initial evidence or a precomputed batch dict containing parameter 
             and discrepancy values
@@ -764,6 +764,13 @@ class BayesianOptimization(ParameterInference):
         output_names = [target_name] + model.parameter_names
         super(BayesianOptimization, self).__init__(model, output_names,
                                                    batch_size=batch_size, **kwargs)
+
+        if not isinstance(bounds, dict):
+            raise ValueError("Keyword `bounds` must be a dictionary "
+                             "`{'parameter_name': (lower, upper), ... }`")
+
+        # turn bounds dict into a list in the same order as parameter_names
+        bounds = [bounds[n] for n in model.parameter_names]
 
         self.target_name = target_name
         target_model = \

--- a/elfi/methods/parameter_inference.py
+++ b/elfi/methods/parameter_inference.py
@@ -745,12 +745,13 @@ class BayesianOptimization(ParameterInference):
         target_model : GPyRegression, optional
         acquisition_method : Acquisition, optional
             Method of acquiring evidence points. Defaults to LCBSC.
-        acq_noise_cov : float, or np.array of shape (n_params,) or np.array of shape (n_params, n_params), optional
+        acq_noise_cov : float or np.array, optional
             Covariance of the noise added in the default LCBSC acquisition method.
+            If an array, should have the shape (n_params,) or (n_params, n_params).
         bounds : dict
             The region where to estimate the posterior for each parameter in
             model.parameters.
-            `{'t1':(lower, upper), ... }`
+            `{'parameter_name':(lower, upper), ... }`
         initial_evidence : int, dict, optional
             Number of initial evidence or a precomputed batch dict containing parameter 
             and discrepancy values

--- a/tests/functional/test_inference.py
+++ b/tests/functional/test_inference.py
@@ -105,7 +105,7 @@ def test_BOLFI():
     log_d = NodeReference(m['d'], state=dict(_operation=np.log), model=m, name='log_d')
 
     bolfi = elfi.BOLFI(log_d, initial_evidence=20, update_interval=10, batch_size=5,
-                       bounds=[(-2,2), (-1, 1)], acq_noise_cov=.1)
+                       bounds={'t1':(-2,2), 't2':(-1, 1)}, acq_noise_cov=.1)
     n = 300
     res = bolfi.infer(300)
     assert bolfi.target_model.n_evidence == 300

--- a/tests/unit/test_bo.py
+++ b/tests/unit/test_bo.py
@@ -13,9 +13,10 @@ def test_BO(ma2):
     n_init = 20
     res_init = elfi.Rejection(log_d, batch_size=5).sample(n_init, quantile=1)
 
+    bounds = {n:(-2, 2) for n in ma2.parameter_names}
     bo = elfi.BayesianOptimization(log_d, initial_evidence=res_init.outputs,
                                    update_interval=10, batch_size=5,
-                                   bounds=[(-2,2)]*len(ma2.parameter_names))
+                                   bounds=bounds)
     assert bo.target_model.n_evidence == n_init
     assert bo.n_evidence == n_init
     assert bo._n_precomputed == n_init

--- a/tests/unit/test_methods.py
+++ b/tests/unit/test_methods.py
@@ -33,7 +33,7 @@ def test_BOLFI_short(ma2, distribution_test):
     log_d = elfi.Operation(np.log, ma2['d'])
 
     bolfi = elfi.BOLFI(log_d, initial_evidence=10, update_interval=10, batch_size=5,
-                       bounds=[(-2,2), (-1, 1)])
+                       bounds={'t1':(-2,2), 't2':(-1, 1)})
     n = 20
     res = bolfi.infer(n)
     assert bolfi.target_model.n_evidence == n


### PR DESCRIPTION
Bounds must be given as dict for BO/BOLFI. This ensures that their order stays the same as for model parameters.