### PR TITLE
Loosen a too tight time limit

### DIFF
--- a/tests/functional/test_simulation_reuse.py
+++ b/tests/functional/test_simulation_reuse.py
@@ -1,9 +1,6 @@
 import pytest
 import time
 
-import numpy as np
-import scipy.stats as ss
-
 import elfi
 
 
@@ -19,7 +16,7 @@ def test_pool(sleep_model):
     td = time.time() - ts
     # Will make 5/.25 = 20 evaluations with mean time of .1 secs, so 2 secs total on
     # average. Allow some slack although still on rare occasions this may fail.
-    assert td > 1.3
+    assert td > 1.2
 
     # Instantiating new inference with the same pool should be faster because we
     # use the prepopulated pool
@@ -27,7 +24,7 @@ def test_pool(sleep_model):
     ts = time.time()
     res = rej.sample(5, quantile=quantile)
     td = time.time() - ts
-    assert td < 1.3
+    assert td < 1.2
 
     # It should work if we remove the simulation, since the Rejection sampling
     # only requires the parameters and the discrepancy
@@ -36,7 +33,7 @@ def test_pool(sleep_model):
     ts = time.time()
     res = rej.sample(5, quantile=quantile)
     td = time.time() - ts
-    assert td < 1.3
+    assert td < 1.2
 
     # It should work even if we remove the discrepancy, since the discrepancy can be recomputed
     # from the stored summary
@@ -45,7 +42,7 @@ def test_pool(sleep_model):
     ts = time.time()
     res = rej.sample(5, quantile=quantile)
     td = time.time() - ts
-    assert td < 1.3
+    assert td < 1.2
 
 
 


### PR DESCRIPTION
This test failed too often because of a too strict time limit.