### PR TITLE
Make gradient function argument optional in minimize

### DIFF
--- a/elfi/methods/bo/acquisition.py
+++ b/elfi/methods/bo/acquisition.py
@@ -99,7 +99,7 @@ class AcquisitionBase:
 
         obj = lambda x: self.evaluate(x, t)
         grad_obj = lambda x: self.evaluate_gradient(x, t)
-        minloc, minval = minimize(obj, grad_obj, self.model.bounds, self.prior, self.n_inits, self.max_opt_iters)
+        minloc, minval = minimize(obj, self.model.bounds, grad_obj, self.prior, self.n_inits, self.max_opt_iters)
         x = np.tile(minloc, (n_values, 1))
 
         # add some noise for more efficient exploration

--- a/elfi/methods/bo/utils.py
+++ b/elfi/methods/bo/utils.py
@@ -11,17 +11,17 @@ def stochastic_optimization(fun, bounds, maxiter=1000, polish=True, seed=0):
 
 
 # TODO: allow argument for specifying the optimization algorithm
-def minimize(fun, grad, bounds, prior=None, n_start_points=10, maxiter=1000, random_state=None):
+def minimize(fun, bounds, grad=None, prior=None, n_start_points=10, maxiter=1000, random_state=None):
     """ Called to find the minimum of function 'fun'.
     
     Parameters
     ----------
     fun : callable
         Function to minimize.
-    grad : callable
-        Gradient of fun.
     bounds : list of tuples
         Bounds for each parameter.
+    grad : callable
+        Gradient of fun or None.
     prior : scipy-like distribution object
         Used for sampling initialization points. If None, samples uniformly.
     n_start_points : int, optional
@@ -57,7 +57,10 @@ def minimize(fun, grad, bounds, prior=None, n_start_points=10, maxiter=1000, ran
 
     # Run optimization from each initialization point
     for i in range(n_start_points):
-        result = fmin_l_bfgs_b(fun, start_points[i, :], fprime=grad, bounds=bounds, maxiter=maxiter)
+        if grad is not None:
+            result = fmin_l_bfgs_b(fun, start_points[i, :], fprime=grad, bounds=bounds, maxiter=maxiter)
+        else:
+            result = fmin_l_bfgs_b(fun, start_points[i, :], approx_grad=True, bounds=bounds, maxiter=maxiter)
         locs.append(result[0])
         vals[i] = result[1]
 

--- a/elfi/methods/posteriors.py
+++ b/elfi/methods/posteriors.py
@@ -59,8 +59,8 @@ class BolfiPosterior:
         if self.threshold is None:
             # TODO: the evidence could be used for a good guess for starting locations
             minloc, minval = minimize(self.model.predict_mean,
-                                      self.model.predictive_gradient_mean,
                                       self.model.bounds,
+                                      self.model.predictive_gradient_mean,
                                       self.prior,
                                       self.n_inits,
                                       self.max_opt_iters,

--- a/tests/functional/test_inference.py
+++ b/tests/functional/test_inference.py
@@ -123,8 +123,12 @@ def test_BOLFI():
     post = bolfi.extract_posterior()
 
     # TODO: make cleaner.
-    post_ml = minimize(post._neg_unnormalized_loglikelihood, post._gradient_neg_unnormalized_loglikelihood,
-                       post.model.bounds, post.prior, post.n_inits, post.max_opt_iters,
+    post_ml = minimize(post._neg_unnormalized_loglikelihood,
+                       post.model.bounds,
+                       post._gradient_neg_unnormalized_loglikelihood,
+                       post.prior,
+                       post.n_inits,
+                       post.max_opt_iters,
                        random_state=post.random_state)[0]
     # TODO: Here we cannot use the minimize method due to sharp edges in the posterior.
     #       If a MAP method is implemented, one must be able to set the optimizer and

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -17,11 +17,19 @@ def test_stochastic_optimization():
     assert abs(val - 0.0) < 1e-5
 
 
-def test_minimize():
+def test_minimize_with_known_gradient():
     fun = lambda x : x[0]**2 + (x[1]-1)**4
     grad = lambda x : np.array([2*x[0], 4*(x[1]-1)**3])
     bounds = ((-2, 2), (-2, 3))
-    loc, val = minimize(fun, grad, bounds)
+    loc, val = minimize(fun, bounds, grad)
+    assert np.isclose(val, 0, atol=0.01)
+    assert np.allclose(loc, np.array([0, 1]), atol=0.02)
+
+
+def test_minimize_with_approx_gradient():
+    fun = lambda x : x[0]**2 + (x[1]-1)**4
+    bounds = ((-2, 2), (-2, 3))
+    loc, val = minimize(fun, bounds)
     assert np.isclose(val, 0, atol=0.01)
     assert np.allclose(loc, np.array([0, 1]), atol=0.02)
 


### PR DESCRIPTION
As the argument is not a strict functional requirement for
using the minimization interface, it should be optional to
allow better using minimize() as a general functionality.