### PR TITLE
Easier client switching

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,15 +5,12 @@ dev
 ---
 
 - Fix elfi.Prior and NoneType error #203
-
-dev
----
-
 - Fix a bug preventing the reuse of ArrayPool data with a new inference
 - Added a possibility to pickle ArrayPool
 - Added ArrayPool.open to read a closed pool from disk
 - Refactored Sample and SmcSample classes
 - Added elfi.new_model method
+- Made elfi.set_client method to accept clients as strings.
 
 
 0.6 (2017-07-03)

--- a/elfi/client.py
+++ b/elfi/client.py
@@ -1,4 +1,5 @@
 import logging
+import importlib
 from types import ModuleType
 from collections import OrderedDict
 
@@ -9,7 +10,6 @@ from elfi.compiler import OutputCompiler, ObservedCompiler, AdditionalNodesCompi
     ReduceCompiler, RandomStateCompiler
 from elfi.loader import ObservedLoader, AdditionalNodesLoader, RandomStateLoader, \
     PoolLoader
-from elfi.store import OutputPool
 
 logger = logging.getLogger(__name__)
 
@@ -31,6 +31,11 @@ def get_client():
 def set_client(client=None):
     """Set the current ELFI client instance."""
     global _client
+
+    if isinstance(client, str):
+        m = importlib.import_module('elfi.clients.{}'.format(client))
+        client = m.Client()
+
     _client = client
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -188,6 +188,5 @@ def distribution_test():
         if hasattr(distribution, 'gradient_logpdf'):
             glpdf_none, glpdf1, glpdf2 = test_non_rvs_attr('gradient_logpdf', distribution, rvs, *args, **kwargs)
 
-
     return run
 


### PR DESCRIPTION
#### Summary:
Allows changing the client with strings

```
elfi.set_client('ipyparallel')
```

#### Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD3 (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
