### PR TITLE
Easier model saving and loading

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+dev
+---
+
+- Easier saving and loading of ElfiModel
+- Renamed elfi.set_current_model to elfi.set_default_model
+- Renamed elfi.get_current_model to elfi.get_default_model
+
 0.6.1 (2017-07-21)
 ------------------
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -32,8 +32,9 @@ Below is the API for creating generative models.
 
 .. autosummary::
    elfi.new_model
-   elfi.get_current_model
-   elfi.set_current_model
+   elfi.load_model
+   elfi.get_default_model
+   elfi.set_default_model
 
 .. currentmodule:: elfi.visualization.visualization
 

--- a/elfi/model/elfi_model.py
+++ b/elfi/model/elfi_model.py
@@ -7,10 +7,10 @@ the simulator or a summary statistic.
 https://en.wikipedia.org/wiki/Directed_acyclic_graph
 """
 
-import os
-import pickle
 import inspect
 import logging
+import os
+import pickle
 import re
 import uuid
 from functools import partial
@@ -83,7 +83,7 @@ def new_model(name=None, set_default=True):
 
 
 def load_model(name, prefix=None, set_default=True):
-    """Load the pickled ElfiModel
+    """Load the pickled ElfiModel.
 
     Assumes there exists a file "name.pkl" in the current directory. Also sets the loaded
     model as the default model for new nodes.
@@ -102,7 +102,6 @@ def load_model(name, prefix=None, set_default=True):
     ElfiModel
 
     """
-
     model = ElfiModel.load(name, prefix=prefix)
     if set_default:
         set_default_model(model)
@@ -388,22 +387,24 @@ class ElfiModel(GraphicalModel):
         return kopy
 
     def save(self, prefix=None):
-        """Save the current model to pickled file
+        """Save the current model to pickled file.
 
         Parameters
         ----------
         prefix : str, optional
-            Path to the directory under which to save the model. Default is the current working directory.
+            Path to the directory under which to save the model. Default is the current working
+            directory.
+
         """
         path = self.name + '.pkl'
         if prefix is not None:
             os.makedirs(prefix, exist_ok=True)
             path = os.path.join(prefix, path)
-        pickle.dump(self, open(path, "wb" ) )
+        pickle.dump(self, open(path, "wb"))
 
     @classmethod
     def load(cls, name, prefix):
-        """Load the pickled ElfiModel
+        """Load the pickled ElfiModel.
 
         Assumes there exists a file "name.pkl" in the current directory.
 

--- a/tests/unit/test_elfi_model.py
+++ b/tests/unit/test_elfi_model.py
@@ -1,3 +1,5 @@
+import os
+
 import numpy as np
 import pytest
 
@@ -69,17 +71,30 @@ class TestElfiModel:
 
         assert 'MA2' not in ma2.observed
 
+    def test_save_load(self, ma2):
+        name = ma2.name
+        ma2.save()
+        ma2 = elfi.load_model(name)
+        os.remove(name + '.pkl')
+
+        # Same with a prefix
+        prefix = 'models_dir'
+        ma2.save(prefix)
+        ma2 = elfi.load_model(name, prefix)
+        os.remove(os.path.join(prefix, name + '.pkl'))
+        os.removedirs(prefix)
+
 
 class TestNodeReference:
     def test_name_argument(self):
         # This is important because it is used when passing NodeReferences as
         # InferenceMethod arguments
-        em.set_current_model()
+        em.set_default_model()
         ref = em.NodeReference(name='test')
         assert str(ref) == 'test'
 
     def test_name_determination(self):
-        em.set_current_model()
+        em.set_default_model()
         node = em.NodeReference()
         assert node.name == 'node'
 


### PR DESCRIPTION
#### Summary:
Allows saving the `ElfiModel` with `model.save()`. Loading can be done with either `elfi.load_model` or `ElfiModel.load`.

#### Please make sure
- You have updated the CHANGELOG.rst
- You have updated the documentation (if applicable)

#### Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD3 (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
