### PR TITLE
Improve sub seed generation performance

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ dev
 - Easier saving and loading of ElfiModel
 - Renamed elfi.set_current_model to elfi.set_default_model
 - Renamed elfi.get_current_model to elfi.get_default_model
+- Improved performance when rerunning inference using stored data
 
 0.6.1 (2017-07-21)
 ------------------

--- a/elfi/loader.py
+++ b/elfi/loader.py
@@ -162,15 +162,18 @@ class RandomStateLoader(Loader):  # noqa: D101
             random_state = get_np_random
             key = 'operation'
         elif isinstance(seed, (int, np.int32, np.uint32)):
-            # TODO: In the future, we could use
-            #       https://pypi.python.org/pypi/randomstate to enable jumps?
-            random_state = np.random.RandomState(get_sub_seed(seed, batch_index))
+            # TODO: In the future, we could use https://pypi.python.org/pypi/randomstate to enable
+            # jumps?
+            sub_seed, context.sub_seed_cache = get_sub_seed(seed,
+                                                            batch_index,
+                                                            cache=context.sub_seed_cache)
+            random_state = np.random.RandomState(sub_seed)
         else:
             raise ValueError("Seed of type {} is not supported".format(seed))
 
         # Assign the random state or its acquirer function to the corresponding node
-        _random_node = '_random_state'
-        if compiled_net.has_node(_random_node):
-            compiled_net.node[_random_node][key] = random_state
+        node_name = '_random_state'
+        if compiled_net.has_node(node_name):
+            compiled_net.node[node_name][key] = random_state
 
         return compiled_net

--- a/elfi/methods/parameter_inference.py
+++ b/elfi/methods/parameter_inference.py
@@ -1244,13 +1244,12 @@ class BOLFI(BayesianOptimization):
 
         self.target_model.is_sampling = True  # enables caching for default RBF kernel
 
-        random_state = np.random.RandomState(self.seed)
         tasks_ids = []
         ii_initial = 0
 
         # sampling is embarrassingly parallel, so depending on self.client this may parallelize
         for ii in range(n_chains):
-            seed = get_sub_seed(random_state, ii)
+            seed = get_sub_seed(self.seed, ii)
             # discard bad initialization points
             while np.isinf(posterior.logpdf(initials[ii_initial])):
                 ii_initial += 1

--- a/elfi/model/elfi_model.py
+++ b/elfi/model/elfi_model.py
@@ -128,9 +128,11 @@ class ComputationContext:
     ----------
     seed : int
     batch_size : int
-    pool : elfi.OutputPool
+    pool : OutputPool
     num_submissions : int
         Number of submissions using this context.
+    sub_seed_cache : dict
+        Caches the sub seed generation state variables. This is
 
     Notes
     -----
@@ -165,6 +167,7 @@ class ComputationContext:
 
         self._batch_size = batch_size or 1
         self._seed = random_seed() if seed is None else seed
+        self.sub_seed_cache = {}
         self._pool = pool
 
         # Count the number of submissions from this context

--- a/elfi/model/tools.py
+++ b/elfi/model/tools.py
@@ -139,7 +139,7 @@ def vectorize(operation, constants=None, dtype=None):
 
 
 def unpack_meta(*inputs, **kwinputs):
-    """Update `kwinputs` with keys and values from its `meta` dictionary."""
+    """Update ``kwinputs`` with keys and values from its ``meta`` dictionary."""
     if 'meta' in kwinputs:
         new_kwinputs = kwinputs['meta'].copy()
         new_kwinputs.update(kwinputs)
@@ -149,7 +149,7 @@ def unpack_meta(*inputs, **kwinputs):
 
 
 def prepare_seed(*inputs, **kwinputs):
-    """Update `kwinputs` with the seed from its value `random_state`."""
+    """Update ``kwinputs`` with the seed from its value ``random_state``."""
     if 'random_state' in kwinputs:
         # Get the seed for this batch, assuming np.RandomState instance
         seed = kwinputs['random_state'].get_state()[1][0]
@@ -157,7 +157,7 @@ def prepare_seed(*inputs, **kwinputs):
         # Since we may not be the first operation to use this seed, lets generate a
         # a sub seed using this seed
         sub_seed_index = kwinputs.get('index_in_batch') or 0
-        kwinputs['seed'] = get_sub_seed(np.random.RandomState(seed), sub_seed_index)
+        kwinputs['seed'] = get_sub_seed(seed, sub_seed_index)
 
     return inputs, kwinputs
 

--- a/elfi/utils.py
+++ b/elfi/utils.py
@@ -68,16 +68,15 @@ def nbunch_ancestors(G, nbunch):
     return ancestors
 
 
-def get_sub_seed(random_state, sub_seed_index, high=2**31):
+def get_sub_seed(seed, sub_seed_index, high=2**31, cache=None):
     """Return a sub seed.
 
     The returned sub seed is unique for its index, i.e. no two indexes can
-    return the same sub_seed. Same random_state will also always
-    produce the same sequence.
+    return the same sub_seed.
 
     Parameters
     ----------
-    random_state : np.random.RandomState, int
+    seed : int
     sub_seed_index : int
     high : int
         upper limit for the range of sub seeds (exclusive)
@@ -94,8 +93,10 @@ def get_sub_seed(random_state, sub_seed_index, high=2**31):
     functions available.
 
     """
-    if isinstance(random_state, (int, np.integer)):
-        random_state = np.random.RandomState(random_state)
+    if isinstance(seed, np.random.RandomState):
+        raise ValueError('Seed cannot be a random state')
+
+    random_state = np.random.RandomState(seed)
 
     if sub_seed_index >= high:
         raise ValueError("Sub seed index {} is out of range".format(sub_seed_index))
@@ -110,4 +111,7 @@ def get_sub_seed(random_state, sub_seed_index, high=2**31):
         seen.update(sub_seeds)
         n_unique = len(seen)
 
-    return sub_seeds[-1]
+    if cache is None:
+        return sub_seeds[-1]
+    else:
+        return sub_seeds, cache

--- a/elfi/utils.py
+++ b/elfi/utils.py
@@ -80,38 +80,50 @@ def get_sub_seed(seed, sub_seed_index, high=2**31, cache=None):
     sub_seed_index : int
     high : int
         upper limit for the range of sub seeds (exclusive)
+    cache : dict or None, optional
+        If provided, cached state will be used to compute the next sub_seed.
 
     Returns
     -------
-    int
-        from interval [0, high - 1]
+    int or tuple
+        The seed will be from the interval [0, high - 1]. If cache is provided, will also return
+        the updated cache.
 
     Notes
     -----
+    Caching the sub seed generation avoids slowing down of recomputing results with stored values
+    from ``OutputPool``:s.
+
     There is no guarantee how close the random_states initialized with sub_seeds may end
-    up to each other. Better option is to use PRNG:s that have an advance or jump
+    up to each other. Better option would be to use PRNG:s that have an advance or jump
     functions available.
 
     """
     if isinstance(seed, np.random.RandomState):
         raise ValueError('Seed cannot be a random state')
-
-    random_state = np.random.RandomState(seed)
-
-    if sub_seed_index >= high:
+    elif sub_seed_index >= high:
         raise ValueError("Sub seed index {} is out of range".format(sub_seed_index))
 
-    n_unique = 0
-    n_unique_required = sub_seed_index + 1
+    if cache and len(cache['seen']) < sub_seed_index + 1:
+        random_state = cache['random_state']
+        seen = cache['seen']
+    else:
+        random_state = np.random.RandomState(seed)
+        seen = set()
+
     sub_seeds = None
-    seen = set()
+    n_unique_required = sub_seed_index + 1
+    n_unique = len(seen)
+
     while n_unique != n_unique_required:
         n_draws = n_unique_required - n_unique
         sub_seeds = random_state.randint(high, size=n_draws, dtype='uint32')
         seen.update(sub_seeds)
         n_unique = len(seen)
 
-    if cache is None:
-        return sub_seeds[-1]
+    sub_seed = sub_seeds[-1]
+    if cache is not None:
+        cache = {'random_state': random_state, 'seen': seen}
+        return sub_seed, cache
     else:
-        return sub_seeds, cache
+        return sub_seed

--- a/tests/functional/test_randomness.py
+++ b/tests/functional/test_randomness.py
@@ -46,12 +46,10 @@ def test_global_random_state_usage(simple_model):
 
 def test_get_sub_seed():
     n = 100
-    rs = np.random.RandomState()
-    state = rs.get_state()
+    seed = np.random.randint(2**31)
     sub_seeds = []
     for i in range(n):
-        rs.set_state(state)
-        sub_seeds.append(get_sub_seed(rs, i, n))
+        sub_seeds.append(get_sub_seed(seed, i, n))
 
     assert len(np.unique(sub_seeds)) == n
 

--- a/tests/functional/test_randomness.py
+++ b/tests/functional/test_randomness.py
@@ -53,6 +53,15 @@ def test_get_sub_seed():
 
     assert len(np.unique(sub_seeds)) == n
 
+    # Test the cached version
+    cache = {}
+    sub_seeds_cached = []
+    for i in range(n):
+        sub_seed, cache = get_sub_seed(seed, i, n, cache=cache)
+        sub_seeds_cached.append(sub_seed)
+
+    assert np.array_equal(sub_seeds, sub_seeds_cached)
+
 
 # Helpers
 


### PR DESCRIPTION
#### Summary:
Reduces the time to generate sub seeds. With very large `OutputPool`s the sub seed generation took too much time when rerunning the inference using the stored values in the pool.

#### Please make sure
- You have updated the CHANGELOG.rst
- You have updated the documentation (if applicable)

#### Copyright and Licensing

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD3 (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
