### PR TITLE
Fix Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,10 @@ matrix:
     - mkdir -p /Users/travis/.matplotlib
     - "echo 'backend: TkAgg' > /Users/travis/.matplotlib/matplotlibrc"
     - brew update
-    - brew install python3
-    - virtualenv env -p python3
-    - source env/bin/activate
+    - brew upgrade python
+    - pip3 install virtualenv
+    - virtualenv py3env -p python3
+    - source py3env/bin/activate
 
 cache: pip
 

--- a/tests/functional/test_consistency.py
+++ b/tests/functional/test_consistency.py
@@ -11,12 +11,12 @@ import elfi
 def check_consistent_sample(sample, sample_diff, sample_same):
     assert not np.array_equal(sample.outputs['t1'], sample_diff.outputs['t1'])
 
-    assert np.array_equal(sample.outputs['t1'], sample_same.outputs['t1'])
-    assert np.array_equal(sample.outputs['t2'], sample_same.outputs['t2'])
+    assert np.allclose(sample.outputs['t1'], sample_same.outputs['t1'])
+    assert np.allclose(sample.outputs['t2'], sample_same.outputs['t2'])
 
     # BOLFI does not have d in its outputs
     if 'd' in sample.outputs:
-        assert np.array_equal(sample.outputs['d'], sample_same.outputs['d'])
+        assert np.allclose(sample.outputs['d'], sample_same.outputs['d'])
 
 
 @pytest.mark.usefixtures('with_all_clients')
@@ -101,7 +101,8 @@ def test_bo(ma2):
     check_consistent_sample(res, res_diff, res_same)
 
     assert not np.array_equal(res.x_min, res_diff.x_min)
-    assert np.array_equal(res.x_min, res_same.x_min)
+    assert np.allclose(res.x_min['t1'], res_same.x_min['t1'], atol=1e-07)
+    assert np.allclose(res.x_min['t2'], res_same.x_min['t2'], atol=1e-07)
 
 
 # TODO: skipped in travis due to NUTS initialization failing too often. Should be fixed.


### PR DESCRIPTION
- Fix Mac setup in Travis after changes in Homebrew.
- Relax consistency tests from `np.array_equal` to `np.allclose` to decrease the chance of random failures.