### PR TITLE
Fix tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,11 +11,11 @@ matrix:
     before_install:
     - mkdir -p /Users/travis/.matplotlib
     - "echo 'backend: TkAgg' > /Users/travis/.matplotlib/matplotlibrc"
-    - brew update
-    - brew upgrade python
-    - pip3 install virtualenv
-    - virtualenv py3env -p python3
-    - source py3env/bin/activate
+    - travis_retry wget "http://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh" -O miniconda.sh
+    - "bash miniconda.sh -b -p $HOME/miniconda"
+    - "export PATH=$HOME/miniconda/bin:$PATH"
+    - "conda create -y -n elfi python=3.6 scipy"
+    - "source activate elfi"
 
 cache: pip
 

--- a/elfi/methods/post_processing.py
+++ b/elfi/methods/post_processing.py
@@ -239,11 +239,11 @@ def adjust_posterior(sample, model, summary_names, parameter_names=None, adjustm
 
     Examples
     --------
-    >>> import elfi
-    >>> from elfi.examples import gauss
-    >>> m = gauss.get_model()
-    >>> res = elfi.Rejection(m['d'], output_names=['ss_mean', 'ss_var']).sample(1000)
-    >>> adj = adjust_posterior(res, m, ['ss_mean', 'ss_var'], ['mu'], LinearAdjustment())
+    import elfi
+    from elfi.examples import gauss
+    m = gauss.get_model()
+    res = elfi.Rejection(m['d'], output_names=['ss_mean', 'ss_var']).sample(1000)
+    adj = adjust_posterior(res, m, ['ss_mean', 'ss_var'], ['mu'], LinearAdjustment())
 
     """
     adjustment = _get_adjustment(adjustment)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,8 +26,6 @@ def pytest_addoption(parser):
         default="all",
         help="perform the tests for the specified client (default all)")
 
-    parser.addoption("--skipslow", action="store_true", help="skip slow tests")
-
 
 """Functional fixtures"""
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -195,9 +195,7 @@ def no_op(data):
 
 @pytest.fixture()
 def sleep_model(request):
-    """The true param will be half of the given sleep time
-
-    """
+    """The true param will be half of the given sleep time."""
     ub_sec = request.param or .5
     m = elfi.ElfiModel()
     elfi.Constant(ub_sec, model=m, name='ub')
@@ -207,6 +205,20 @@ def sleep_model(request):
     elfi.Distance('euclidean', m['summary'], model=m, name='d')
 
     m.observed['slept'] = ub_sec / 2
+    return m
+
+
+def rowsummer(x, batch_size, random_state):
+    return np.sum(x, keepdims=True, axis=1)
+
+
+@pytest.fixture()
+def multivariate_model(request):
+    ndim = request.param
+    m = elfi.ElfiModel()
+    elfi.Prior(ss.multivariate_normal, [0]*ndim, model=m, name='t1')
+    elfi.Simulator(rowsummer, m['t1'], observed=np.array([[0]]), model=m, name='sim')
+    elfi.Distance('euclidean', m['sim'], model=m, name='d')
     return m
 
 

--- a/tests/functional/test_inference.py
+++ b/tests/functional/test_inference.py
@@ -8,8 +8,6 @@ from elfi.examples import ma2
 from elfi.methods.bo.utils import minimize, stochastic_optimization
 from elfi.model.elfi_model import NodeReference
 
-slow = pytest.mark.skipif(
-    pytest.config.getoption("--skipslow"), reason="--skipslow argument given")
 """
 This file tests inference methods point estimates with an informative data from the
 MA2 process.
@@ -90,7 +88,7 @@ def test_smc():
     assert res.populations[-1].n_batches < 6
 
 
-@slow
+@pytest.mark.slowtest
 @pytest.mark.usefixtures('with_all_clients', 'skip_travis')
 def test_BOLFI():
     m, true_params = setup_ma2_with_informative_data()

--- a/tests/unit/test_bo.py
+++ b/tests/unit/test_bo.py
@@ -46,8 +46,8 @@ def test_async(ma2):
     bounds = {n: (-2, 2) for n in ma2.parameter_names}
     bo = elfi.BayesianOptimization(
         ma2, 'd', initial_evidence=0, update_interval=2, batch_size=2, bounds=bounds, async=True)
-    samples = 5
-    bo.infer(samples)
+    n_samples = 5
+    bo.infer(n_samples)
 
 
 @pytest.mark.usefixtures('with_all_clients')
@@ -60,10 +60,10 @@ def test_BO_works_with_zero_init_samples(ma2):
     assert bo.n_evidence == 0
     assert bo.n_precomputed_evidence == 0
     assert bo.n_initial_evidence == 0
-    samples = 4
-    bo.infer(samples)
-    assert bo.target_model.n_evidence == samples
-    assert bo.n_evidence == samples
+    n_samples = 4
+    bo.infer(n_samples)
+    assert bo.target_model.n_evidence == n_samples
+    assert bo.n_evidence == n_samples
     assert bo.n_precomputed_evidence == 0
     assert bo.n_initial_evidence == 0
 
@@ -160,7 +160,7 @@ class Test_MaxVar:
 
         """
         from GPy.models.gradient_checker import GradientChecker
-        n_pts_test = 100
+        n_pts_test = 20
         n_dim_fixture = len(acq_maxvar.model.bounds)
 
         checker_grad = GradientChecker(acq_maxvar.evaluate,
@@ -175,6 +175,7 @@ class Test_MaxVar:
 class Test_RandMaxVar:
     """Run a collection of tests for the RandMaxVar acquisition."""
 
+    @pytest.mark.slowtest
     def test_acq_bounds(self, acq_randmaxvar):
         """Check if the acquisition is performed within the bounds.
 
@@ -202,6 +203,7 @@ class Test_RandMaxVar:
 class Test_ExpIntVar:
     """Run a collection of tests for the ExpIntVar acquisition."""
 
+    @pytest.mark.slowtest
     def test_acq_bounds(self, acq_expintvar):
         """Check if the acquisition is performed within the bounds.
 

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -30,6 +30,8 @@ def test_batch_handler(simple_model):
 
 
 def test_multiprocessing_kwargs(simple_model):
+    pre = elfi.get_client()
+
     m = simple_model
     num_proc = 2
     elfi.set_client('multiprocessing', num_processes=num_proc)
@@ -39,5 +41,7 @@ def test_multiprocessing_kwargs(simple_model):
     elfi.set_client('multiprocessing', processes=num_proc)
     rej = elfi.Rejection(m['k1'])
     assert rej.client.num_cores == num_proc
+
+    elfi.set_client(pre)
 
 # TODO: add testing that client is cleared from tasks after they are retrieved

--- a/tests/unit/test_examples.py
+++ b/tests/unit/test_examples.py
@@ -69,13 +69,13 @@ def test_gauss_2d_mean():
 def test_Ricker():
     m = ricker.get_model()
     rej = elfi.Rejection(m, m['d'], batch_size=10)
-    rej.sample(20)
+    rej.sample(20, quantile=0.1)
 
 
 def test_Lorenz():
     m = lorenz.get_model()
     rej = elfi.Rejection(m, m['d'], batch_size=10)
-    rej.sample(20)
+    rej.sample(20, quantile=0.1)
 
 
 def test_gnk():

--- a/tests/unit/test_mcmc.py
+++ b/tests/unit/test_mcmc.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 
 from elfi.methods import mcmc
 
@@ -31,6 +32,7 @@ class TestMetropolis():
         assert np.allclose(cov, true_cov, atol=0.3, rtol=0.1)
 
 
+@pytest.mark.slowtest
 class TestNUTS():
     def test_nuts(self):
         n_samples = 100000

--- a/tests/unit/test_model_selection.py
+++ b/tests/unit/test_model_selection.py
@@ -1,7 +1,10 @@
+import pytest
+
 import elfi
 from elfi.examples import gauss, ma2
 
 
+@pytest.mark.slowtest
 def test_compare_models():
     m = gauss.get_model()
     res1 = elfi.Rejection(m['d']).sample(100)


### PR DESCRIPTION
- For local quick-n-dirty testing: Removed option `--skipslow` from pytest. Use `-m "not slowtest"` instead.
- Fix problem with not resetting client in a test
- Setup MacOS/Travis to use miniconda instead of homebrew to allow choosing Python version
- (Includes a fixture related to `vis` branch)