### PR TITLE
Fix bug with zero total number iterations in progress bar

### DIFF
--- a/elfi/methods/results.py
+++ b/elfi/methods/results.py
@@ -208,9 +208,11 @@ class Sample(ParameterInferenceResult):
         return np.array(list(self.sample_means.values()))
 
     def __getstate__(self):
+        """Says to pickle the exact objects to pickle."""
         return self.meta, self.__dict__
 
     def __setstate__(self, state):
+        """Says to pickle which objects to unpickle."""
         self.meta, self.__dict__ = state
 
     def save(self, fname=None):

--- a/elfi/visualization/visualization.py
+++ b/elfi/visualization/visualization.py
@@ -278,6 +278,3 @@ def progress_bar(iteration, total, prefix='', suffix='', decimals=1, length=100,
         print('\r%s |%s| %s%% %s' % (prefix, bar, percent, suffix), end='\r')
         if iteration == total:
             print()
-    else:
-        print("Can't output progress bar. Number of total iterations is zero. \n"
-              "Please check your model description or put bar argument to False.")

--- a/elfi/visualization/visualization.py
+++ b/elfi/visualization/visualization.py
@@ -271,9 +271,13 @@ def progress_bar(iteration, total, prefix='', suffix='', decimals=1, length=100,
         Bar fill character
 
     """
-    percent = ("{0:." + str(decimals) + "f}").format(100 * (iteration / float(total)))
-    filled_length = int(length * iteration // total)
-    bar = fill * filled_length + '-' * (length - filled_length)
-    print('\r%s |%s| %s%% %s' % (prefix, bar, percent, suffix), end='\r')
-    if iteration == total:
-        print()
+    if total > 0:
+        percent = ("{0:." + str(decimals) + "f}").format(100 * (iteration / float(total)))
+        filled_length = int(length * iteration // total)
+        bar = fill * filled_length + '-' * (length - filled_length)
+        print('\r%s |%s| %s%% %s' % (prefix, bar, percent, suffix), end='\r')
+        if iteration == total:
+            print()
+    else:
+        print("Can't output progress bar. Number of total iterations is zero. \n"
+              "Please check your model description or put bar argument to False.")


### PR DESCRIPTION
#### Summary:
Depending on model, in some cases progress bar might crash because of zero number of `self._objective_n_batches`. This PR prevents crashing and gives kind caution for users.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elfi-dev/elfi/288)
<!-- Reviewable:end -->
