### PR TITLE
Minimizer constraints for BOLFI

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,7 @@ Changelog
 =========
 
 
+- Added ability to set minimizer constrains for BOLFI
 - Enable bolfi.fit using only pre-generated initial evidence points
 - Fixed a bug causing random seed number to be deterministic
 - Updated requirements-dev.txt with pytest>=4.4

--- a/elfi/methods/bo/acquisition.py
+++ b/elfi/methods/bo/acquisition.py
@@ -27,7 +27,8 @@ class AcquisitionBase:
                  max_opt_iters=1000,
                  noise_var=None,
                  exploration_rate=10,
-                 seed=None):
+                 seed=None,
+                 constraints=None):
         """Initialize AcquisitionBase.
 
         Parameters
@@ -52,12 +53,14 @@ class AcquisitionBase:
         seed : int, optional
             Seed for getting consistent acquisition results. Used in getting random
             starting locations in acquisition function optimization.
-
+        constraints : {Constraint, dict} or List of {Constraint, dict}, optional
+            Additional model constraints.
         """
         self.model = model
         self.prior = prior
         self.n_inits = int(n_inits)
         self.max_opt_iters = int(max_opt_iters)
+        self.constraints = constraints
 
         if noise_var is not None and np.asanyarray(noise_var).ndim > 1:
             raise ValueError("Noise variance must be a float or 1d vector of variances "
@@ -121,6 +124,8 @@ class AcquisitionBase:
         xhat, _ = minimize(
             obj,
             self.model.bounds,
+            method='L-BFGS-B' if self.constraints is None else 'SLSQP',
+            constrains=self.constraints,
             grad=grad_obj,
             prior=self.prior,
             n_start_points=self.n_inits,

--- a/elfi/methods/bo/acquisition.py
+++ b/elfi/methods/bo/acquisition.py
@@ -126,7 +126,7 @@ class AcquisitionBase:
             obj,
             self.model.bounds,
             method='L-BFGS-B' if self.constraints is None else 'SLSQP',
-            constrains=self.constraints,
+            constraints=self.constraints,
             grad=grad_obj,
             prior=self.prior,
             n_start_points=self.n_inits,

--- a/elfi/methods/bo/acquisition.py
+++ b/elfi/methods/bo/acquisition.py
@@ -121,10 +121,10 @@ class AcquisitionBase:
         xhat, _ = minimize(
             obj,
             self.model.bounds,
-            grad_obj,
-            self.prior,
-            self.n_inits,
-            self.max_opt_iters,
+            grad=grad_obj,
+            prior=self.prior,
+            n_start_points=self.n_inits,
+            maxiter=self.max_opt_iters,
             random_state=self.random_state)
 
         # Create n copies of the minimum
@@ -322,10 +322,10 @@ class MaxVar(AcquisitionBase):
         # Obtaining the location where the variance is maximised.
         theta_max, _ = minimize(_negate_eval,
                                 gp.bounds,
-                                _negate_eval_grad,
-                                self.prior,
-                                self.n_inits,
-                                self.max_opt_iters,
+                                grad=_negate_eval_grad,
+                                prior=self.prior,
+                                n_start_points=self.n_inits,
+                                maxiter=self.max_opt_iters,
                                 random_state=self.random_state)
 
         # Using the same location for all points in theta batch.

--- a/elfi/methods/bo/acquisition.py
+++ b/elfi/methods/bo/acquisition.py
@@ -55,6 +55,7 @@ class AcquisitionBase:
             starting locations in acquisition function optimization.
         constraints : {Constraint, dict} or List of {Constraint, dict}, optional
             Additional model constraints.
+
         """
         self.model = model
         self.prior = prior

--- a/elfi/methods/bo/utils.py
+++ b/elfi/methods/bo/utils.py
@@ -36,6 +36,7 @@ def stochastic_optimization(fun, bounds, maxiter=1000, polish=True, seed=0):
 def minimize(fun,
              bounds,
              method='L-BFGS-B',
+             constraints=None,
              grad=None,
              prior=None,
              n_start_points=10,
@@ -49,8 +50,10 @@ def minimize(fun,
         Function to minimize.
     bounds : list of tuples
         Bounds for each parameter.
-    method : string
+    method : str or callable, optional
         Minimizer method to use, defaults to L-BFGS-B.
+    constraints : {Constraint, dict} or List of {Constraint, dict}, optional
+        Constraints definition (only for COBLYA, SLSQP and trust-constr).
     grad : callable
         Gradient of fun or None.
     prior : scipy-like distribution object
@@ -89,7 +92,8 @@ def minimize(fun,
     vals = np.empty(n_start_points)
     for i in range(n_start_points):
         result = scipy.optimize.minimize(fun, start_points[i, :],
-                                         method=method, jac=grad, bounds=bounds)
+                                         method=method, jac=grad,
+                                         bounds=bounds, constraints=constraints)
         locs.append(result['x'])
         vals[i] = result['fun']
 

--- a/elfi/methods/bo/utils.py
+++ b/elfi/methods/bo/utils.py
@@ -49,6 +49,8 @@ def minimize(fun,
         Function to minimize.
     bounds : list of tuples
         Bounds for each parameter.
+    method : string
+        Minimizer method to use, defaults to L-BFGS-B.
     grad : callable
         Gradient of fun or None.
     prior : scipy-like distribution object

--- a/elfi/methods/bo/utils.py
+++ b/elfi/methods/bo/utils.py
@@ -33,9 +33,9 @@ def stochastic_optimization(fun, bounds, maxiter=1000, polish=True, seed=0):
     return result.x, result.fun
 
 
-# TODO: allow argument for specifying the optimization algorithm
 def minimize(fun,
              bounds,
+             method='L-BFGS-B',
              grad=None,
              prior=None,
              n_start_points=10,
@@ -87,7 +87,7 @@ def minimize(fun,
     vals = np.empty(n_start_points)
     for i in range(n_start_points):
         result = scipy.optimize.minimize(fun, start_points[i, :],
-                                         method='L-BFGS-B', jac=grad, bounds=bounds)
+                                         method=method, jac=grad, bounds=bounds)
         locs.append(result['x'])
         vals[i] = result['fun']
 

--- a/elfi/methods/posteriors.py
+++ b/elfi/methods/posteriors.py
@@ -66,10 +66,10 @@ class BolfiPosterior:
             minloc, minval = minimize(
                 self.model.predict_mean,
                 self.model.bounds,
-                self.model.predictive_gradient_mean,
-                self.prior,
-                self.n_inits,
-                self.max_opt_iters,
+                grad=self.model.predictive_gradient_mean,
+                prior=self.prior,
+                n_start_points=self.n_inits,
+                maxiter=self.max_opt_iters,
                 random_state=self.random_state)
             self.threshold = minval
             logger.info("Using optimized minimum value (%.4f) of the GP discrepancy mean "

--- a/tests/functional/test_inference.py
+++ b/tests/functional/test_inference.py
@@ -124,10 +124,10 @@ def test_BOLFI():
     post_ml = minimize(
         post._neg_unnormalized_loglikelihood,
         post.model.bounds,
-        post._gradient_neg_unnormalized_loglikelihood,
-        post.prior,
-        post.n_inits,
-        post.max_opt_iters,
+        grad=post._gradient_neg_unnormalized_loglikelihood,
+        prior=post.prior,
+        n_start_points=post.n_inits,
+        maxiter=post.max_opt_iters,
         random_state=post.random_state)[0]
     # TODO: Here we cannot use the minimize method due to sharp edges in the posterior.
     #       If a MAP method is implemented, one must be able to set the optimizer and

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -54,7 +54,7 @@ def test_minimize_with_constraints():
     # Test constraint y >= x
     constraints = ({'type': 'ineq',
                     'fun': lambda x : x[1] - x[0]})
-    loc, val = minimize(fun, bounds, constraints, method='SLSQP')
+    loc, val = minimize(fun, bounds, constraints=constraints, method='SLSQP')
     assert np.isclose(val, 0, atol=0.01)
     assert np.allclose(loc, np.array([0, 1]), atol=0.02)
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -31,7 +31,7 @@ def test_minimize_with_known_gradient():
         return np.array([2 * x[0], 4 * (x[1] - 1)**3])
 
     bounds = ((-2, 2), (-2, 3))
-    loc, val = minimize(fun, bounds, grad)
+    loc, val = minimize(fun, bounds, grad=grad)
     assert np.isclose(val, 0, atol=0.01)
     assert np.allclose(loc, np.array([0, 1]), atol=0.02)
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -46,6 +46,19 @@ def test_minimize_with_approx_gradient():
     assert np.allclose(loc, np.array([0, 1]), atol=0.02)
 
 
+def test_minimize_with_constraints():
+    def fun(x):
+        return x[0]**2 + (x[1] - 1)**4
+
+    bounds = ((-2, 2), (-2, 3))
+    # Test constraint y >= x
+    constraints = ({'type': 'ineq',
+                    'fun': lambda x : x[1] - x[0]})
+    loc, val = minimize(fun, bounds, constraints, method='SLSQP')
+    assert np.isclose(val, 0, atol=0.01)
+    assert np.allclose(loc, np.array([0, 1]), atol=0.02)
+
+
 def test_weighted_var():
     # 1d case
     std = .3


### PR DESCRIPTION
#### Summary:
This PR implements constraints for the minimizer used by BOLFI.
I've been working on a project (together with @umbertosimola and @dbarg) where we infer two parameters x and y using BOLFI. The parameter space is constrained by ``x**2 + y**2 < R**2`` for some constant R. However there was no way to call the underlying ``scipy.optimize.minimize`` routine with constraints. These changes pass the ``constraints`` argument to the minimizer from the AcquisitionBase class, allowing for the definition of an acquisition method with constraints on the parameter space.

#### Please make sure
- You have updated the CHANGELOG.rst
  - I haven't yet, should I just add the PR name to the top of the list?
- You have updated the documentation (if applicable)
  - I've updated docstrings however ``make docs`` did not run since I don't have permission to read the content url (http://research.cs.aalto.fi/pml/software/elfi/docs/0.6.2/)

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):
@pelssers

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD3 (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
