### PR TITLE
Enable BOLFI-fit using only initial evidence points.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,8 @@ Changelog
 =========
 
 
+- Enable bolfi.fit using only pre-generated initial evidence points
+
 0.7.4 (2019-03-07)
 ------------------
 - Add sampler option `algorithm` for bolfi-posterior-sampling

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,9 @@ Changelog
 
 
 - Enable bolfi.fit using only pre-generated initial evidence points
+- Fixed a bug causing random seed number to be deterministic
+- Updated requirements-dev.txt with pytest>=4.4
+
 
 0.7.4 (2019-03-07)
 ------------------

--- a/elfi/methods/parameter_inference.py
+++ b/elfi/methods/parameter_inference.py
@@ -1206,7 +1206,7 @@ class BOLFI(BayesianOptimization):
         posterior : elfi.methods.posteriors.BolfiPosterior
 
         """
-        if self.state['n_batches'] == 0:
+        if self.state['n_evidence'] == 0:
             raise ValueError('Model is not fitted yet, please see the `fit` method.')
 
         return BolfiPosterior(self.target_model, threshold=threshold, prior=ModelPrior(self.model))

--- a/elfi/utils.py
+++ b/elfi/utils.py
@@ -27,7 +27,7 @@ def random_seed():
 
     Alternative would be to use os.urandom(4) cast as int.
     """
-    return np.random.RandomState().get_state()[1][1]
+    return np.random.RandomState().get_state()[1][0]
 
 
 def random_name(length=4, prefix=''):

--- a/elfi/utils.py
+++ b/elfi/utils.py
@@ -27,7 +27,7 @@ def random_seed():
 
     Alternative would be to use os.urandom(4) cast as int.
     """
-    return np.random.RandomState().get_state()[1][0]
+    return np.random.RandomState().get_state()[1][1]
 
 
 def random_name(length=4, prefix=''):

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 # Testing
-pytest>=3.8
+pytest>=4.4
 tox>=2.4.1
 coverage>=4.2
 pytest-cov>=2.4.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,7 +31,7 @@ def pytest_addoption(parser):
 """Functional fixtures"""
 
 
-@pytest.fixture(scope="session", params=[native]) # , eipp, mp
+@pytest.fixture(scope="session", params=[eipp, mp, native])
 def client(request):
     """Provides a fixture for all the different supported clients
     """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,7 +31,7 @@ def pytest_addoption(parser):
 """Functional fixtures"""
 
 
-@pytest.fixture(scope="session", params=[native, eipp, mp])
+@pytest.fixture(scope="session", params=[native]) # , eipp, mp
 def client(request):
     """Provides a fixture for all the different supported clients
     """


### PR DESCRIPTION
#### Summary:
Previously fitting bolfi required at least one new evidence point in addition to initial pre-generated evidence points

#### Please make sure
- You have updated the CHANGELOG.rst
- You have updated the documentation (if applicable)

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD3 (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
