### PR TITLE
Update travis tests to py36

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,10 @@ matrix:
  include:
   - os: linux
     language: python
-    python: 3.5
+    python: 3.6
   - os: linux
     language: python
-    python: 3.6
+    python: 3.7
   - os: osx
     language: generic
     before_install:
@@ -25,6 +25,6 @@ install:
   - pip install -e .
 
 script:
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ipcluster start -n 2 --daemon ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ipcluster start -n 2 --daemonize ; fi
   #- travis_wait 20 make test
   - make test

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,7 @@
 Changelog
 =========
 
+- Add python 3.7 to travis tests and remove python 3.5 due to clash with dask
 - Modify progress bar to better indicate ABC-SMC inference status
 - Change networkx support from 1.X to 2.X
 - Improve docstrings in elfi.methods.bo.acquisition


### PR DESCRIPTION
#### Summary:
Include python 3.7 to Travis setup and remove python 3.5 due to clash with dask

#### Please make sure

- [x] You have updated the CHANGELOG.rst
- [x] You have provided a short summary of your changes (see previous section)
- [x] You have listed the copyright holder for the work you are submitting (see next section)

If your contribution adds, removes or somehow changes the functional behavior of the package, please check that

- [x] You have included or updated all the relevant documentation
- [x] The proposed changes pass all unit tests (check step 6 of CONTRIBUTING.rst for details)
- [x] You have added appropriate unit tests to ensure the new features behave as expected

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD3 (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
