### PR TITLE
Fix reference to parameter_inference-module

### DIFF
--- a/docs/usage/implementing-methods.rst
+++ b/docs/usage/implementing-methods.rst
@@ -7,7 +7,7 @@ random state handling. In a typical case these happen "automatically" behind the
 when the algorithms are built on top of the provided interface classes.
 
 The base class for parameter inference classes is the `ParameterInference`_ interface
-which is found from the ``elfi.methods.parameter_inference`` module. Among the methods in
+which is found from the ``elfi.methods.inference.parameter_inference`` module. Among the methods in
 the interface, those that must be implemented raise a ``NotImplementedError``. In
 addition, you probably also want to override at least the ``update`` and ``__init__``
 methods.
@@ -15,7 +15,7 @@ methods.
 Let's create an empty skeleton for a custom method that includes just the minimal set of
 methods to create a working algorithm in ELFI::
 
-    from elfi.methods.parameter_inference import ParameterInference
+    from elfi.methods.inference.parameter_inference import ParameterInference
 
     class CustomMethod(ParameterInference):
 
@@ -285,6 +285,6 @@ This is because all the parameter values will still come from the same priors.
 Parameter inference base class
 ------------------------------
 
-.. autoclass:: elfi.methods.parameter_inference.ParameterInference
+.. autoclass:: elfi.methods.inference.parameter_inference.ParameterInference
    :members:
    :inherited-members:


### PR DESCRIPTION
#### Summary:
Fixing bugs caused by the split of parameter_inference-module

#### Please make sure

- [ ] You have updated the CHANGELOG.rst
- [x] You have provided a short summary of your changes (see previous section)
- [x] You have listed the copyright holder for the work you are submitting (see next section)

If your contribution adds, removes or somehow changes the functional behavior of the package, please check that

- [x] You have included or updated all the relevant documentation 
- [ ] You have added appropriate unit tests to ensure the new features behave as expected

and the proposed changes pass all unit tests (check step 6 of CONTRIBUTING.rst for details)

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): @hpesonen 

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD3 (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
