### PR TITLE
Change reference from InferenceMethod to ParameterInference.

### DIFF
--- a/elfi/methods/inference/samplers.py
+++ b/elfi/methods/inference/samplers.py
@@ -80,7 +80,7 @@ class Rejection(Sampler):
             Additional outputs from the model to be included in the inference result, e.g.
             corresponding summaries to the acquired samples
         kwargs:
-            See InferenceMethod
+            See ParameterInference
 
         """
         model, discrepancy_name = self._resolve_model(model, discrepancy_name)
@@ -332,7 +332,7 @@ class SMC(Sampler):
             Additional outputs from the model to be included in the inference result, e.g.
             corresponding summaries to the acquired samples
         kwargs:
-            See InferenceMethod
+            See ParameterInference
 
         """
         model, discrepancy_name = self._resolve_model(model, discrepancy_name)
@@ -586,7 +586,7 @@ class AdaptiveDistanceSMC(SMC):
             Additional outputs from the model to be included in the inference result, e.g.
             corresponding summaries to the acquired samples
         kwargs:
-            See InferenceMethod
+            See ParameterInference
 
         """
         model, discrepancy_name = self._resolve_model(model, discrepancy_name)
@@ -695,7 +695,7 @@ class AdaptiveThresholdSMC(SMC):
         densratio_estimation : DensityRatioEstimation, optional
             Density ratio estimation object defining parameters for KLIEP
         kwargs:
-            See InferenceMethod
+            See ParameterInference
 
         """
         model, discrepancy_name = self._resolve_model(model, discrepancy_name)

--- a/tests/unit/test_elfi_model.py
+++ b/tests/unit/test_elfi_model.py
@@ -88,7 +88,7 @@ class TestElfiModel:
 class TestNodeReference:
     def test_name_argument(self):
         # This is important because it is used when passing NodeReferences as
-        # InferenceMethod arguments
+        # ParameterInference arguments
         em.set_default_model()
         ref = em.NodeReference(name='test')
         assert str(ref) == 'test'


### PR DESCRIPTION
#### Summary:
`Sampler`s refer to `InferenceMethod` in docstring instead of `ParameterInference`. This has been fixed. 

#### Please make sure

- [ ] You have updated the CHANGELOG.rst
- [ ] You have provided a short summary of your changes (see previous section)
- [ ] You have listed the copyright holder for the work you are submitting (see next section)

If your contribution adds, removes or somehow changes the functional behavior of the package, please check that

- [ ] You have included or updated all the relevant documentation 
- [ ] You have added appropriate unit tests to ensure the new features behave as expected

and the proposed changes pass all unit tests (check step 6 of CONTRIBUTING.rst for details)

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD3 (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
