### PR TITLE
Feature/add reference point in pairplots

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,8 @@
 Changelog
 =========
 
+- Add `plot_predicted_node_pairs` in visualization.py.
+
 0.8.0 (2021-03-29)
 ------------------
 - Merge adaptive distance ABC-SMC and ABC-SMC functionalities

--- a/elfi/__init__.py
+++ b/elfi/__init__.py
@@ -22,7 +22,7 @@ from elfi.model.extensions import ScipyLikeDistribution as Distribution
 from elfi.store import OutputPool, ArrayPool
 from elfi.visualization.visualization import nx_draw as draw
 from elfi.visualization.visualization import plot_params_vs_node
-from elfi.visualization.visualization import plot_predicted_node_pairs
+from elfi.visualization.visualization import plot_predicted_summaries
 from elfi.methods.bo.gpy_regression import GPyRegression
 
 __author__ = 'ELFI authors'

--- a/elfi/__init__.py
+++ b/elfi/__init__.py
@@ -22,6 +22,7 @@ from elfi.model.extensions import ScipyLikeDistribution as Distribution
 from elfi.store import OutputPool, ArrayPool
 from elfi.visualization.visualization import nx_draw as draw
 from elfi.visualization.visualization import plot_params_vs_node
+from elfi.visualization.visualization import plot_predicted_node_pairs
 from elfi.methods.bo.gpy_regression import GPyRegression
 
 __author__ = 'ELFI authors'

--- a/elfi/visualization/visualization.py
+++ b/elfi/visualization/visualization.py
@@ -498,7 +498,7 @@ def plot_predicted_summaries(model=None,
                              axes=None,
                              add_observed=True,
                              **kwargs):
-    """Pairplots of summary statistics calculated from prior predictive distribution.
+    """Pairplots of 1D summary statistics calculated from prior predictive distribution.
 
     Parameters
     ----------

--- a/elfi/visualization/visualization.py
+++ b/elfi/visualization/visualization.py
@@ -250,92 +250,6 @@ def plot_traces(result, selector=None, axes=None, **kwargs):
     return axes
 
 
-class ProgressBar:
-    """Progress bar monitoring the inference process.
-
-    Attributes
-    ----------
-    prefix : str, optional
-        Prefix string
-    suffix : str, optional
-        Suffix string
-    decimals : int, optional
-        Positive number of decimals in percent complete
-    length : int, optional
-        Character length of bar
-    fill : str, optional
-        Bar fill character
-    scaling : int, optional
-        Integer used to scale current iteration and total iterations of the progress bar
-
-    """
-
-    def __init__(self, prefix='', suffix='', decimals=1, length=100, fill='='):
-        """Construct progressbar for monitoring.
-
-        Parameters
-        ----------
-        prefix : str, optional
-            Prefix string
-        suffix : str, optional
-            Suffix string
-        decimals : int, optional
-            Positive number of decimals in percent complete
-        length : int, optional
-            Character length of bar
-        fill : str, optional
-            Bar fill character
-
-        """
-        self.prefix = prefix
-        self.suffix = suffix
-        self.decimals = 1
-        self.length = length
-        self.fill = fill
-        self.scaling = 0
-        self.finished = False
-
-    def update_progressbar(self, iteration, total):
-        """Print updated progress bar in console.
-
-        Parameters
-        ----------
-        iteration : int
-            Integer indicating completed iterations
-        total : int
-            Integer indicating total number of iterations
-
-        """
-        if iteration >= total:
-            percent = ("{0:." + str(self.decimals) + "f}").\
-                format(100.0)
-            bar = self.fill * self.length
-            if not self.finished:
-                print('%s [%s] %s%% %s' % (self.prefix, bar, percent, self.suffix))
-                self.finished = True
-        elif total - self.scaling > 0:
-            percent = ("{0:." + str(self.decimals) + "f}").\
-                format(100 * ((iteration - self.scaling) / float(total - self.scaling)))
-            filled_length = int(self.length * (iteration - self.scaling) // (total - self.scaling))
-            bar = self.fill * filled_length + '-' * (self.length - filled_length)
-            print('%s [%s] %s%% %s' % (self.prefix, bar, percent, self.suffix), end='\r')
-
-    def reinit_progressbar(self, scaling=0, reinit_msg=""):
-        """Reinitialize new round of progress bar.
-
-        Parameters
-        ----------
-        scaling : int, optional
-            Integer used to scale current and total iterations of the progress bar
-        reinit_msg : str, optional
-            Message printed before restarting an empty progess bar on a new line
-
-        """
-        self.scaling = scaling
-        self.finished = False
-        print(reinit_msg)
-
-
 def plot_params_vs_node(node, n_samples=100, func=None, seed=None, axes=None, **kwargs):
     """Plot some realizations of parameters vs. `node`.
 
@@ -553,13 +467,13 @@ def plot_gp(gp, parameter_names, axes=None, resol=50,
     return axes
 
 
-def predicted_nodes(model=None, 
-                    summary_names=None,
-                    n_samples=100,
-                    seed=None,
-                    bins=20,
-                    axes=None,
-                    **kwargs):
+def plot_predicted_node_pairs(model=None, 
+                              summary_names=None,
+                              n_samples=100,
+                              seed=None,
+                              bins=20,
+                              axes=None,
+                              **kwargs):
     """Pairplots of summary statistics calculated from prior predictive distribution.
 
     Parameters
@@ -578,3 +492,89 @@ def predicted_nodes(model=None,
     dot_size = kwargs.pop('s', 10)
     samples = model.generate(batch_size=n_samples, outputs=summary_names, seed=seed)
     plot_pairs(samples, selector=None, bins=bins, axes=axes, s=dot_size)
+
+
+class ProgressBar:
+    """Progress bar monitoring the inference process.
+
+    Attributes
+    ----------
+    prefix : str, optional
+        Prefix string
+    suffix : str, optional
+        Suffix string
+    decimals : int, optional
+        Positive number of decimals in percent complete
+    length : int, optional
+        Character length of bar
+    fill : str, optional
+        Bar fill character
+    scaling : int, optional
+        Integer used to scale current iteration and total iterations of the progress bar
+
+    """
+
+    def __init__(self, prefix='', suffix='', decimals=1, length=100, fill='='):
+        """Construct progressbar for monitoring.
+
+        Parameters
+        ----------
+        prefix : str, optional
+            Prefix string
+        suffix : str, optional
+            Suffix string
+        decimals : int, optional
+            Positive number of decimals in percent complete
+        length : int, optional
+            Character length of bar
+        fill : str, optional
+            Bar fill character
+
+        """
+        self.prefix = prefix
+        self.suffix = suffix
+        self.decimals = 1
+        self.length = length
+        self.fill = fill
+        self.scaling = 0
+        self.finished = False
+
+    def update_progressbar(self, iteration, total):
+        """Print updated progress bar in console.
+
+        Parameters
+        ----------
+        iteration : int
+            Integer indicating completed iterations
+        total : int
+            Integer indicating total number of iterations
+
+        """
+        if iteration >= total:
+            percent = ("{0:." + str(self.decimals) + "f}").\
+                format(100.0)
+            bar = self.fill * self.length
+            if not self.finished:
+                print('%s [%s] %s%% %s' % (self.prefix, bar, percent, self.suffix))
+                self.finished = True
+        elif total - self.scaling > 0:
+            percent = ("{0:." + str(self.decimals) + "f}").\
+                format(100 * ((iteration - self.scaling) / float(total - self.scaling)))
+            filled_length = int(self.length * (iteration - self.scaling) // (total - self.scaling))
+            bar = self.fill * filled_length + '-' * (self.length - filled_length)
+            print('%s [%s] %s%% %s' % (self.prefix, bar, percent, self.suffix), end='\r')
+
+    def reinit_progressbar(self, scaling=0, reinit_msg=""):
+        """Reinitialize new round of progress bar.
+
+        Parameters
+        ----------
+        scaling : int, optional
+            Integer used to scale current and total iterations of the progress bar
+        reinit_msg : str, optional
+            Message printed before restarting an empty progess bar on a new line
+
+        """
+        self.scaling = scaling
+        self.finished = False
+        print(reinit_msg)

--- a/elfi/visualization/visualization.py
+++ b/elfi/visualization/visualization.py
@@ -467,7 +467,7 @@ def plot_gp(gp, parameter_names, axes=None, resol=50,
     return axes
 
 
-def plot_predicted_node_pairs(model=None, 
+def plot_predicted_node_pairs(model=None,
                               summary_names=None,
                               n_samples=100,
                               seed=None,

--- a/elfi/visualization/visualization.py
+++ b/elfi/visualization/visualization.py
@@ -157,7 +157,7 @@ def plot_marginals(samples, selector=None, bins=20, axes=None, **kwargs):
     return axes
 
 
-def plot_pairs(samples, selector=None, bins=20, axes=None, **kwargs):
+def plot_pairs(samples, selector=None, bins=20, reference_value=None, axes=None, **kwargs):
     """Plot pairwise relationships as a matrix with marginals on the diagonal.
 
     The y-axis of marginal histograms are scaled.
@@ -195,14 +195,37 @@ def plot_pairs(samples, selector=None, bins=20, axes=None, **kwargs):
                 axes[idx_row, idx_col].bar(bin_edges[:-1],
                                            hist,
                                            bar_width,
-                                           bottom=min_samples,
-                                           **kwargs)
+                                           **kwargs)  # bottom=min_samples,
+                if reference_value is not None:
+                    axes[idx_row, idx_col].plot(
+                        [reference_value[key_row], reference_value[key_row]],
+                        [hist.min(), hist.max()],
+                        color='red', alpha=0.8, linewidth=2)
+                axes[idx_row, idx_col].get_yaxis().set_ticklabels([])
+                # axes[idx_row, idx_col].yaxis.tick_right()
+
+                axes[idx_row, idx_col].axis([min_samples, max_samples, hist.min(), hist.max()])
+
             else:
                 axes[idx_row, idx_col].scatter(samples[key_col],
                                                samples[key_row],
                                                s=dot_size,
                                                edgecolor=edgecolor,
                                                **kwargs)
+                if reference_value is not None:
+                    axes[idx_row, idx_col].plot(
+                        [samples[key_col].min(), samples[key_col].max()],
+                        [reference_value[key_row], reference_value[key_row]],
+                        color='red', alpha=0.8, linewidth=2)
+                    axes[idx_row, idx_col].plot(
+                        [reference_value[key_col], reference_value[key_col]],
+                        [samples[key_row].min(), samples[key_row].max()],
+                        color='red', alpha=0.8, linewidth=2)
+
+                axes[idx_row, idx_col].axis([samples[key_col].min(),
+                                             samples[key_col].max(),
+                                             samples[key_row].min(),
+                                             samples[key_row].max()])
 
         axes[idx_row, 0].set_ylabel(key_row)
         axes[-1, idx_row].set_xlabel(key_row)
@@ -467,13 +490,14 @@ def plot_gp(gp, parameter_names, axes=None, resol=50,
     return axes
 
 
-def plot_predicted_node_pairs(model=None,
-                              summary_names=None,
-                              n_samples=100,
-                              seed=None,
-                              bins=20,
-                              axes=None,
-                              **kwargs):
+def plot_predicted_summaries(model=None,
+                             summary_names=None,
+                             n_samples=100,
+                             seed=None,
+                             bins=20,
+                             axes=None,
+                             add_observed=True,
+                             **kwargs):
     """Pairplots of summary statistics calculated from prior predictive distribution.
 
     Parameters
@@ -481,17 +505,26 @@ def plot_predicted_node_pairs(model=None,
     model: elfi.Model
         Model which is explored.
     summary_names: list of strings
-        Summary statistics which are pairplotted.
+        Nodes which are pairplotted.
     n_samples: int, optional
         How many samples are drawn from the model.
     bins : int, optional
         Number of bins in histograms.
     axes : one or an iterable of plt.Axes, optional
+    add_observed: boolean, optional
+        Add observed summary points in pairplots
 
     """
     dot_size = kwargs.pop('s', 10)
     samples = model.generate(batch_size=n_samples, outputs=summary_names, seed=seed)
-    plot_pairs(samples, selector=None, bins=bins, axes=axes, s=dot_size)
+    reference_value = model.generate(with_values=model.observed, outputs=summary_names)
+    reference_value = reference_value if add_observed else None
+    plot_pairs(samples,
+               selector=None,
+               bins=bins,
+               axes=axes,
+               reference_value=reference_value,
+               s=dot_size)
 
 
 class ProgressBar:

--- a/elfi/visualization/visualization.py
+++ b/elfi/visualization/visualization.py
@@ -551,3 +551,30 @@ def plot_gp(gp, parameter_names, axes=None, resol=50,
                 axes[jy, ix].set_xlabel(parameter_names[ix])
 
     return axes
+
+
+def predicted_nodes(model=None, 
+                    summary_names=None,
+                    n_samples=100,
+                    seed=None,
+                    bins=20,
+                    axes=None,
+                    **kwargs):
+    """Pairplots of summary statistics calculated from prior predictive distribution.
+
+    Parameters
+    ----------
+    model: elfi.Model
+        Model which is explored.
+    summary_names: list of strings
+        Summary statistics which are pairplotted.
+    n_samples: int, optional
+        How many samples are drawn from the model.
+    bins : int, optional
+        Number of bins in histograms.
+    axes : one or an iterable of plt.Axes, optional
+
+    """
+    dot_size = kwargs.pop('s', 10)
+    samples = model.generate(batch_size=n_samples, outputs=summary_names, seed=seed)
+    plot_pairs(samples, selector=None, bins=bins, axes=axes, s=dot_size)


### PR DESCRIPTION
#### Summary:
Add the option to plot also observed node values in predicted node plots and renamed the function from `plot_predicted_node_pairs` to `plot_predicted_summaries` to focus the intended usage of the method. In addition, improved the general pair plotting functionality.  

#### Please make sure

- [x] You have updated the CHANGELOG.rst
- [x] You have provided a short summary of your changes (see previous section)
- [x] You have listed the copyright holder for the work you are submitting (see next section)

If your contribution adds, removes or somehow changes the functional behavior of the package, please check that

- [x] You have included or updated all the relevant documentation 
- [ ] You have added appropriate unit tests to ensure the new features behave as expected

and the proposed changes pass all unit tests (check step 6 of CONTRIBUTING.rst for details)

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): @hpesonen 

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD3 (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
