### PR TITLE
Change BOLFI.Sample to report n_evidence instead of n_sim.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,7 @@
 Changelog
 =========
 
+- Fix a bug where precomputed evidence size was not taken into account when reporting BOLFI-results
 - Fix a bug where observable nodes were not colored gray when using `elfi.draw`
 - Add `plot_predicted_node_pairs` in visualization.py.
 

--- a/elfi/methods/inference/bolfi.py
+++ b/elfi/methods/inference/bolfi.py
@@ -587,5 +587,5 @@ class BOLFI(BayesianOptimization):
             parameter_names=self.parameter_names,
             warmup=warmup,
             threshold=float(posterior.threshold),
-            n_sim=self.state['n_sim'],
+            n_sim=self.state['n_evidence'],
             seed=self.seed)


### PR DESCRIPTION
#### Summary:
If given precomputed data to BOLFI, it's not taken into consideration when reporting number of simulations with the posterior sample object. This has been fixed by changing the reported number from `n_sim` to `n_evidence`.

#### Please make sure

- [x] You have updated the CHANGELOG.rst
- [x] You have provided a short summary of your changes (see previous section)
- [ ] You have listed the copyright holder for the work you are submitting (see next section)

If your contribution adds, removes or somehow changes the functional behavior of the package, please check that

- [ ] You have included or updated all the relevant documentation 
- [ ] You have added appropriate unit tests to ensure the new features behave as expected

and the proposed changes pass all unit tests (check step 6 of CONTRIBUTING.rst for details)

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD3 (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
