### PR TITLE
Fix histograms in plot pairs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,7 @@
 Changelog
 =========
 
+- Fix histograms in pair_plot diagonals and improve visual outlook
 - Improve axes creation and visual outlook
 - Fix a bug where precomputed evidence size was not taken into account when reporting BOLFI-results
 - Fix a bug where observable nodes were not colored gray when using `elfi.draw`

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,7 @@
 Changelog
 =========
 
+- Improve axes creation and visual outlook
 - Fix a bug where precomputed evidence size was not taken into account when reporting BOLFI-results
 - Fix a bug where observable nodes were not colored gray when using `elfi.draw`
 - Add `plot_predicted_node_pairs` in visualization.py.

--- a/elfi/visualization/visualization.py
+++ b/elfi/visualization/visualization.py
@@ -89,7 +89,7 @@ def _create_axes(axes, shape, **kwargs):
 
     """
     fig_kwargs = {}
-    kwargs['figsize'] = kwargs.get('figsize', (16, 4 * shape[0]))
+    kwargs['figsize'] = kwargs.get('figsize', (4 * shape[1], 4 * shape[0]))
     for k in ['figsize', 'sharex', 'sharey', 'dpi', 'num']:
         if k in kwargs.keys():
             fig_kwargs[k] = kwargs.pop(k)
@@ -99,7 +99,8 @@ def _create_axes(axes, shape, **kwargs):
     else:
         fig, axes = plt.subplots(ncols=shape[1], nrows=shape[0], **fig_kwargs)
         axes = np.atleast_2d(axes)
-        fig.tight_layout(pad=2.0)
+        fig.tight_layout(h_pad=0.0, w_pad=0.0)
+        fig.subplots_adjust(wspace=0.1, hspace=0.1)
     return axes, kwargs
 
 
@@ -426,15 +427,11 @@ def plot_gp(gp, parameter_names, axes=None, resol=50,
         const = x_evidence[np.argmin(y_evidence), :]
     bounds = bounds or gp.bounds
 
-    cmap = plt.cm.get_cmap("bone")
-
-    plt.subplots_adjust(wspace=0.2, hspace=0.0, left=0.3, right=0.7, top=0.8, bottom=0.05)
+    cmap = plt.cm.get_cmap("Blues")
     for ix in range(n_plots):
         for jy in range(n_plots):
             if ix == jy:
-                axes[jy, ix].scatter(x_evidence[:, ix], y_evidence)
-                axes[jy, ix].set_aspect(aspect=(bounds[ix][1] - bounds[ix][0]) /
-                                               (max(y_evidence) - min(y_evidence)))
+                axes[jy, ix].scatter(x_evidence[:, ix], y_evidence, edgecolors='black', alpha=0.6)
                 axes[jy, ix].get_yaxis().set_ticklabels([])
                 axes[jy, ix].yaxis.tick_right()
                 axes[jy, ix].set_ylabel('Discrepancy')
@@ -444,7 +441,7 @@ def plot_gp(gp, parameter_names, axes=None, resol=50,
                     axes[jy, ix].plot([true_params[parameter_names[ix]],
                                       true_params[parameter_names[ix]]],
                                       [min(y_evidence), max(y_evidence)],
-                                      color='orange', alpha=0.5, linewidth=4)
+                                      color='red', alpha=1.0, linewidth=1)
                 axes[jy, ix].axis([bounds[ix][0], bounds[ix][1], min(y_evidence), max(y_evidence)])
 
             elif ix < jy:
@@ -457,20 +454,22 @@ def plot_gp(gp, parameter_names, axes=None, resol=50,
 
                 z = gp.predict_mean(predictors).reshape(resol, resol)
                 axes[jy, ix].contourf(x, y, z, cmap=cmap)
-                axes[jy, ix].scatter(x_evidence[:, ix], x_evidence[:, jy], color="red", alpha=0.1)
-                axes[jy, ix].set_aspect(aspect=(bounds[ix][1] - bounds[ix][0]) /
-                                               (bounds[jy][1] - bounds[jy][0]))
+                axes[jy, ix].scatter(x_evidence[:, ix],
+                                     x_evidence[:, jy],
+                                     color="red",
+                                     alpha=0.7,
+                                     s=5)
 
                 if true_params is not None:
                     axes[jy, ix].plot([true_params[parameter_names[ix]],
                                       true_params[parameter_names[ix]]],
                                       [bounds[jy][0], bounds[jy][1]],
-                                      color='orange', alpha=0.5, linewidth=4)
+                                      color='red', alpha=1.0, linewidth=1)
 
                     axes[jy, ix].plot([bounds[ix][0], bounds[ix][1]],
                                       [true_params[parameter_names[jy]],
                                       true_params[parameter_names[jy]]],
-                                      color='orange', alpha=0.5, linewidth=4)
+                                      color='red', alpha=1.0, linewidth=1)
 
                 if ix == 0:
                     axes[jy, ix].set_ylabel(parameter_names[jy])


### PR DESCRIPTION
#### Summary:
Histograms in visualization.plot_pairs() were weirdly aligned regarding the actual samples, and this has been fixed. Also added some improvements to visual appearance of the plotting. 

#### Please make sure

- [x] You have updated the CHANGELOG.rst
- [x] You have provided a short summary of your changes (see previous section)
- [ ] You have listed the copyright holder for the work you are submitting (see next section)

If your contribution adds, removes or somehow changes the functional behavior of the package, please check that

- [ ] You have included or updated all the relevant documentation 
- [ ] You have added appropriate unit tests to ensure the new features behave as expected

and the proposed changes pass all unit tests (check step 6 of CONTRIBUTING.rst for details)

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD3 (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
