### PR TITLE
Release v0.8.2

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,7 +1,7 @@
 Changelog
 =========
  
-0.8.1 (2021-10-12)
+0.8.2 (2021-10-13)
 ------------------
 - Relax tightly pinned dependency on a version of dask[distributed]
 - Change lotka-volterra priors to follow the given reference

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-**Version 0.8.1 released!** See the [CHANGELOG](CHANGELOG.rst) and [notebooks](https://github.com/elfi-dev/notebooks).
+**Version 0.8.2 released!** See the [CHANGELOG](CHANGELOG.rst) and [notebooks](https://github.com/elfi-dev/notebooks).
 
 <img src="https://raw.githubusercontent.com/elfi-dev/elfi/dev/docs/logos/elfi_logo_text_nobg.png" width="200" />
 

--- a/elfi/__init__.py
+++ b/elfi/__init__.py
@@ -30,4 +30,4 @@ __author__ = 'ELFI authors'
 __email__ = 'elfi-support@hiit.fi'
 
 # make sure __version_ is on the last non-empty line (read by setup.py)
-__version__ = '0.8.1'
+__version__ = '0.8.2'


### PR DESCRIPTION
0.8.2 (2021-10-13)
------------------
- Relax tightly pinned dependency on a version of dask[distributed]
- Change lotka-volterra priors to follow the given reference
- Fix README.md badges
- Fix a few small issues with CONTRIBUTING.rst
- Add Github Actions based CI workflow
- Add the skeleton of TestBench-functionality for comparing methods
- Fix a bug of plot_traces() not working if there is only 1 chain 
- Fix histograms in pair_plot diagonals and improve visual outlook
- Improve axes creation and visual outlook
- Fix a bug where precomputed evidence size was not taken into account when reporting BOLFI-results
- Fix a bug where observable nodes were not colored gray when using `elfi.draw`
- Add `plot_predicted_node_pairs` in visualization.py.