### PR TITLE
Fix acq_noise_var API

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,8 @@
 Changelog
 =========
 
+- Fix acq_noise_var-bug in acquisition.py. Influenced BOLFI.
+
 0.8.3 (2021-02-17)
 ------------------
 - Add a new inference method: BOLFIRE

--- a/docs/usage/BOLFI.rst
+++ b/docs/usage/BOLFI.rst
@@ -92,7 +92,7 @@ surface is updated after each batch (especially so if the noise is 0!).
 .. code:: ipython3
 
     bolfi = elfi.BOLFI(log_d, batch_size=1, initial_evidence=20, update_interval=10, 
-                       bounds={'t1':(-2, 2), 't2':(-1, 1)}, acq_noise_var=[0.1, 0.1], seed=seed)
+                       bounds={'t1':(-2, 2), 't2':(-1, 1)}, acq_noise_var=0.1, seed=seed)
 
 Sometimes you may have some samples readily available. You could then
 initialize the GP model with a dictionary of previous results by giving

--- a/elfi/methods/bo/acquisition.py
+++ b/elfi/methods/bo/acquisition.py
@@ -62,10 +62,6 @@ class AcquisitionBase:
         self.n_inits = int(n_inits)
         self.max_opt_iters = int(max_opt_iters)
         self.constraints = constraints
-
-        if noise_var is not None and np.asanyarray(noise_var).ndim > 1:
-            raise ValueError("Noise variance must be a float or 1d vector of variances "
-                             "for the different input dimensions.")
         self.noise_var = noise_var
         self.exploration_rate = exploration_rate
         self.random_state = np.random if seed is None else np.random.RandomState(seed)

--- a/elfi/methods/bo/acquisition.py
+++ b/elfi/methods/bo/acquisition.py
@@ -101,7 +101,6 @@ class AcquisitionBase:
         if isinstance(noise_var, dict):
             return list(map(noise_var.get, self.model.parameter_names))
 
-
     def evaluate(self, x, t=None):
         """Evaluate the acquisition function at 'x'.
 

--- a/elfi/methods/bo/acquisition.py
+++ b/elfi/methods/bo/acquisition.py
@@ -62,16 +62,16 @@ class AcquisitionBase:
         self.n_inits = int(n_inits)
         self.max_opt_iters = int(max_opt_iters)
         self.constraints = constraints
-        self._check_noise_var(noise_var)
-        self.noise_var = self._transform_noise_var(noise_var)
+        if noise_var is not None:
+            self._check_noise_var(noise_var)
+            self.noise_var = self._transform_noise_var(noise_var)
+        else:
+            self.noise_var = noise_var
         self.exploration_rate = exploration_rate
         self.random_state = np.random if seed is None else np.random.RandomState(seed)
         self.seed = 0 if seed is None else seed
 
     def _check_noise_var(self, noise_var):
-        if noise_var is None:
-            raise ValueError("Noise variance is None.")
-
         if isinstance(noise_var, dict):
             if not set(noise_var) == set(self.model.parameter_names):
                 raise ValueError("Acquisition noise dictionary should contain all parameters.")

--- a/elfi/methods/bo/gpy_regression.py
+++ b/elfi/methods/bo/gpy_regression.py
@@ -73,6 +73,7 @@ class GPyRegression:
             raise ValueError("Keyword `bounds` must be a dictionary "
                              "`{'parameter_name': (lower, upper), ... }`")
 
+        self.parameter_names = parameter_names
         self.input_dim = input_dim
         self.bounds = bounds
 

--- a/elfi/methods/inference/bolfi.py
+++ b/elfi/methods/inference/bolfi.py
@@ -99,8 +99,6 @@ class BayesianOptimization(ParameterInference):
 
         self.batches_per_acquisition = batches_per_acquisition or self.max_parallel_batches
 
-        self._check_noise_var(acq_noise_var)
-        acq_noise_var = self._transform_noise_var(acq_noise_var)
         self.acquisition_method = acquisition_method or LCBSC(self.target_model,
                                                               prior=ModelPrior(
                                                                   self.model),
@@ -116,39 +114,6 @@ class BayesianOptimization(ParameterInference):
         self.state['n_evidence'] = self.n_precomputed_evidence
         self.state['last_GP_update'] = self.n_initial_evidence
         self.state['acquisition'] = []
-
-    def _check_noise_var(self, noise_var):
-        if noise_var is None:
-            raise ValueError("Noise variance is None.")
-
-        if isinstance(noise_var, dict):
-            if not set(noise_var) == set(self.model.parameter_names):
-                raise ValueError("Acquisition noise dictionary should contain all parameters.")
-
-            if not all(isinstance(x, (int, float)) for x in noise_var.values()):
-                raise ValueError("Acquisition noise dictionary values "
-                                 "should all be int or float.")
-
-            if any([x < 0 for x in noise_var.values()]):
-                raise ValueError("Acquisition noises values should all be "
-                                 "non-negative int or float.")
-
-        elif isinstance(noise_var, (int, float)):
-            if noise_var < 0:
-                raise ValueError("Acquisition noise should be non-negative int or float.")
-        else:
-            raise ValueError("Either acquisition noise is a float or "
-                             "it is a dictionary of floats defining "
-                             "variance for each parameter dimension.")
-
-    def _transform_noise_var(self, noise_var):
-        if isinstance(noise_var, (float, int)):
-            return noise_var
-
-        # return a sorted list of noise variances in the same order than
-        # parameter_names of the model
-        if isinstance(noise_var, dict):
-            return list(map(noise_var.get, self.model.parameter_names))
 
     def _resolve_initial_evidence(self, initial_evidence):
         # Some sensibility limit for starting GP regression

--- a/elfi/methods/inference/bolfi.py
+++ b/elfi/methods/inference/bolfi.py
@@ -121,15 +121,25 @@ class BayesianOptimization(ParameterInference):
         if noise_var is None:
             raise ValueError("Noise variance is None.")
 
-        if not isinstance(noise_var, (int, float, dict)):
+        if isinstance(noise_var, dict):
+            if not set(noise_var) == set(self.model.parameter_names):
+                raise ValueError("Acquisition noise dictionary should contain all parameters.")
+
+            if not all(isinstance(x, (int, float)) for x in noise_var.values()):
+                raise ValueError("Acquisition noise dictionary values "
+                                 "should all be int or float.")
+
+            if any([x < 0 for x in noise_var.values()]):
+                raise ValueError("Acquisition noises values should all be "
+                                 "non-negative int or float.")
+
+        elif isinstance(noise_var, (int, float)):
+            if noise_var < 0:
+                raise ValueError("Acquisition noise should be non-negative int or float.")
+        else:
             raise ValueError("Either acquisition noise is a float or "
                              "it is a dictionary of floats defining "
                              "variance for each parameter dimension.")
-
-        if isinstance(noise_var, dict):
-            same_length = set(noise_var) == set(self.model.parameter_names)
-            if not same_length:
-                raise ValueError("Acquisition noise dictionary should contain all parameters.")
 
     def _transform_noise_var(self, noise_var):
         if isinstance(noise_var, (float, int)):

--- a/elfi/methods/inference/bolfi.py
+++ b/elfi/methods/inference/bolfi.py
@@ -59,9 +59,9 @@ class BayesianOptimization(ParameterInference):
         target_model : GPyRegression, optional
         acquisition_method : Acquisition, optional
             Method of acquiring evidence points. Defaults to LCBSC.
-        acq_noise_var : float or np.array, optional
+        acq_noise_var : float or dict, optional
             Variance(s) of the noise added in the default LCBSC acquisition method.
-            If an array, should be 1d specifying the variance for each dimension.
+            If a dictionary, values should be float specifying the variance for each dimension.
         exploration_rate : float, optional
             Exploration rate of the acquisition method
         batch_size : int, optional
@@ -98,6 +98,9 @@ class BayesianOptimization(ParameterInference):
             self.target_model.update(params, precomputed[target_name])
 
         self.batches_per_acquisition = batches_per_acquisition or self.max_parallel_batches
+
+        self._check_noise_var(acq_noise_var)
+        acq_noise_var = self._transform_noise_var(acq_noise_var)
         self.acquisition_method = acquisition_method or LCBSC(self.target_model,
                                                               prior=ModelPrior(
                                                                   self.model),
@@ -113,6 +116,29 @@ class BayesianOptimization(ParameterInference):
         self.state['n_evidence'] = self.n_precomputed_evidence
         self.state['last_GP_update'] = self.n_initial_evidence
         self.state['acquisition'] = []
+
+    def _check_noise_var(self, noise_var):
+        if noise_var is None:
+            raise ValueError("Noise variance is None.")
+
+        if not isinstance(noise_var, (int, float, dict)):
+            raise ValueError("Either acquisition noise is a float or "
+                             "it is a dictionary of floats defining "
+                             "variance for each parameter dimension.")
+
+        if isinstance(noise_var, dict):
+            same_length = set(noise_var) == set(self.model.parameter_names)
+            if not same_length:
+                raise ValueError("Acquisition noise dictionary should contain all parameters.")
+
+    def _transform_noise_var(self, noise_var):
+        if isinstance(noise_var, (float, int)):
+            return noise_var
+
+        # return a sorted list of noise variances in the same order than
+        # parameter_names of the model
+        if isinstance(noise_var, dict):
+            return list(map(noise_var.get, self.model.parameter_names))
 
     def _resolve_initial_evidence(self, initial_evidence):
         # Some sensibility limit for starting GP regression

--- a/elfi/methods/inference/bolfire.py
+++ b/elfi/methods/inference/bolfire.py
@@ -60,7 +60,8 @@ class BOLFIRE(ParameterInference):
             Number of initial evidence.
         acq_noise_var : float or dict, optional
             Variance(s) of the noise added in the default LCBSC acquisition method.
-            If a dictionary, values should be float specifying the variance for each dimension.        exploration_rate: float, optional
+            If a dictionary, values should be float specifying the variance for each dimension.
+        exploration_rate: float, optional
             Exploration rate of the acquisition method.
         update_interval : int, optional
             How often to update the GP hyperparameters of the target_model.

--- a/elfi/methods/inference/bolfire.py
+++ b/elfi/methods/inference/bolfire.py
@@ -58,10 +58,9 @@ class BOLFIRE(ParameterInference):
             custom target_model is given.
         n_initial_evidence: int, optional
             Number of initial evidence.
-        acq_noise_var: float or np.ndarray, optional
+        acq_noise_var : float or dict, optional
             Variance(s) of the noise added in the default LCBSC acquisition method.
-            If an array, should be 1d specifying the variance for each dimension.
-        exploration_rate: float, optional
+            If a dictionary, values should be float specifying the variance for each dimension.        exploration_rate: float, optional
             Exploration rate of the acquisition method.
         update_interval : int, optional
             How often to update the GP hyperparameters of the target_model.

--- a/elfi/methods/inference/romc.py
+++ b/elfi/methods/inference/romc.py
@@ -86,9 +86,9 @@ class BoDetereministic:
         target_model : GPyRegression, optional
         acquisition_method : Acquisition, optional
             Method of acquiring evidence points. Defaults to LCBSC.
-        acq_noise_var : float or np.array, optional
+        acq_noise_var : float or dict, optional
             Variance(s) of the noise added in the default LCBSC acquisition method.
-            If an array, should be 1d specifying the variance for each dimension.
+            If a dictionary, values should be float specifying the variance for each dimension.
         exploration_rate : float, optional
             Exploration rate of the acquisition method
         batch_size : int, optional

--- a/tests/unit/test_bo.py
+++ b/tests/unit/test_bo.py
@@ -125,6 +125,7 @@ def test_acquisition():
 
     # test Uniform Acquisition
     t = 1
+    acq_noise_var = 0.1
     acquisition_method = acquisition.UniformAcquisition(target_model, noise_var=acq_noise_var)
     new = acquisition_method.acquire(n2, t=t)
     assert new.shape == (n2, n_params)

--- a/tests/unit/test_bo.py
+++ b/tests/unit/test_bo.py
@@ -131,8 +131,6 @@ def test_acquisition():
     assert np.all((new[:, 0] >= bounds['a'][0]) & (new[:, 0] <= bounds['a'][1]))
     assert np.all((new[:, 1] >= bounds['b'][0]) & (new[:, 1] <= bounds['b'][1]))
 
-def test_acq_noise_var():
-    with pytest.raises(ZeroDivisionError):
 
 class Test_MaxVar:
     """Run a collection of tests for the MaxVar acquisition."""

--- a/tests/unit/test_bo.py
+++ b/tests/unit/test_bo.py
@@ -99,7 +99,7 @@ def test_acquisition():
     assert np.all((new[:, 1] >= bounds['b'][0]) & (new[:, 1] <= bounds['b'][1]))
 
     # check acquisition with separate variance for dimensions
-    acq_noise_var = np.random.uniform(0, 5, size=2)
+    acq_noise_var = {'a': 0.1, 'b': 0.5}
     t = 1
     acquisition_method = acquisition.LCBSC(target_model, noise_var=acq_noise_var)
     new = acquisition_method.acquire(n2, t=t)
@@ -111,7 +111,15 @@ def test_acquisition():
     acq_noise_cov = np.random.rand(n_params, n_params) * 0.5
     acq_noise_cov += acq_noise_cov.T
     acq_noise_cov += n_params * np.eye(n_params)
-    t = 1
+    with pytest.raises(ValueError):
+        acquisition.LCBSC(target_model, noise_var=acq_noise_cov)
+
+    # check acquisition with negative variances
+    acq_noise_var = -0.1
+    with pytest.raises(ValueError):
+        acquisition.LCBSC(target_model, noise_var=acq_noise_cov)
+
+    acq_noise_var = {'a': 0.1, 'b': -0.1}
     with pytest.raises(ValueError):
         acquisition.LCBSC(target_model, noise_var=acq_noise_cov)
 
@@ -123,6 +131,8 @@ def test_acquisition():
     assert np.all((new[:, 0] >= bounds['a'][0]) & (new[:, 0] <= bounds['a'][1]))
     assert np.all((new[:, 1] >= bounds['b'][0]) & (new[:, 1] <= bounds['b'][1]))
 
+def test_acq_noise_var():
+    with pytest.raises(ZeroDivisionError):
 
 class Test_MaxVar:
     """Run a collection of tests for the MaxVar acquisition."""

--- a/tests/unit/test_bo.py
+++ b/tests/unit/test_bo.py
@@ -117,11 +117,11 @@ def test_acquisition():
     # check acquisition with negative variances
     acq_noise_var = -0.1
     with pytest.raises(ValueError):
-        acquisition.LCBSC(target_model, noise_var=acq_noise_cov)
+        acquisition.LCBSC(target_model, noise_var=acq_noise_var)
 
     acq_noise_var = {'a': 0.1, 'b': -0.1}
     with pytest.raises(ValueError):
-        acquisition.LCBSC(target_model, noise_var=acq_noise_cov)
+        acquisition.LCBSC(target_model, noise_var=acq_noise_var)
 
     # test Uniform Acquisition
     t = 1


### PR DESCRIPTION
#### Summary:
Changed `AcquisitionBase`constructor API so that user has to explicitly assign `noise_var` to parameters. 
This is to prevent a bug where `noise_var`-elements are assigned arbitrarily to dimensions.

#### Please make sure

- [x] You have updated the CHANGELOG.rst
- [x] You have provided a short summary of your changes (see previous section)
- [x] You have listed the copyright holder for the work you are submitting (see next section)

If your contribution adds, removes or somehow changes the functional behavior of the package, please check that

- [x] You have included or updated all the relevant documentation 
- [x] You have added appropriate unit tests to ensure the new features behave as expected

and the proposed changes pass all unit tests (check step 6 of CONTRIBUTING.rst for details)

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): @hpesonen 

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD3 (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
