### PR TITLE
Require a dictionary for sigma_proposals to be fed in metropolis.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,7 @@
 Changelog
 =========
 
+- Change sigma_proposals-input in metropolis from list to dict
 - Fix acq_noise_var-bug in acquisition.py. Influenced BOLFI.
 
 0.8.3 (2021-02-17)

--- a/elfi/methods/inference/bolfi.py
+++ b/elfi/methods/inference/bolfi.py
@@ -17,7 +17,7 @@ from elfi.methods.bo.utils import stochastic_optimization
 from elfi.methods.inference.parameter_inference import ParameterInference
 from elfi.methods.posteriors import BolfiPosterior
 from elfi.methods.results import BolfiSample, OptimizationResult
-from elfi.methods.utils import arr2d_to_batch, batch_to_arr2d, ceil_to_batch_size
+from elfi.methods.utils import arr2d_to_batch, batch_to_arr2d, ceil_to_batch_size, resolve_sigmas
 from elfi.model.extensions import ModelPrior
 
 logger = logging.getLogger(__name__)
@@ -490,9 +490,9 @@ class BOLFI(BayesianOptimization):
             Defaults to best evidence points.
         algorithm : string, optional
             Sampling algorithm to use. Currently 'nuts'(default) and 'metropolis' are supported.
-        sigma_proposals : np.array
+        sigma_proposals : dict, optional
             Standard deviations for Gaussian proposals of each parameter for Metropolis
-            Markov Chain sampler.
+            Markov Chain sampler. Defaults to 1/10 of surrogate model bound lengths.
         n_evidence : int
             If the regression model is not fitted yet, specify the amount of evidence
 
@@ -525,12 +525,9 @@ class BOLFI(BayesianOptimization):
         tasks_ids = []
         ii_initial = 0
         if algorithm == 'metropolis':
-            if sigma_proposals is None:
-                raise ValueError("Gaussian proposal standard deviations "
-                                 "have to be provided for Metropolis-sampling.")
-            elif sigma_proposals.shape[0] != self.target_model.input_dim:
-                raise ValueError("The length of Gaussian proposal standard "
-                                 "deviations must be n_params.")
+            sigma_proposals = resolve_sigmas(self.target_model.parameter_names,
+                                             sigma_proposals,
+                                             self.target_model.bounds)
 
         # sampling is embarrassingly parallel, so depending on self.client this may parallelize
         for ii in range(n_chains):

--- a/elfi/methods/inference/bolfire.py
+++ b/elfi/methods/inference/bolfire.py
@@ -14,7 +14,7 @@ from elfi.methods.bo.gpy_regression import GPyRegression
 from elfi.methods.inference.parameter_inference import ParameterInference
 from elfi.methods.posteriors import BOLFIREPosterior
 from elfi.methods.results import BOLFIRESample
-from elfi.methods.utils import arr2d_to_batch, batch_to_arr2d
+from elfi.methods.utils import arr2d_to_batch, batch_to_arr2d, resolve_sigmas
 from elfi.model.elfi_model import ElfiModel, Summary
 from elfi.model.extensions import ModelPrior
 
@@ -269,12 +269,9 @@ class BOLFIRE(ParameterInference):
 
         # Check standard deviations of Gaussian proposals when using Metropolis-Hastings
         if algorithm == 'metropolis':
-            if sigma_proposals is None:
-                raise ValueError('Gaussian proposal standard deviations have '
-                                 'to be provided for Metropolis-sampling.')
-            elif sigma_proposals.shape[0] != self.target_model.input_dim:
-                raise ValueError('The length of Gaussian proposal standard '
-                                 'deviations must be n_params.')
+            sigma_proposals = resolve_sigmas(self.target_model.parameter_names,
+                                             sigma_proposals,
+                                             self.target_model.bounds)
 
         posterior = self.extract_result()
         warmup = warmup or n_samples // 2

--- a/elfi/methods/utils.py
+++ b/elfi/methods/utils.py
@@ -2,7 +2,7 @@
 
 import logging
 from math import ceil
-from typing import Union
+from typing import Dict, List, Optional, Union
 
 import numpy as np
 import scipy.stats as ss
@@ -455,3 +455,46 @@ def flat_array_to_dict(names, arr):
     for ii, param_name in enumerate(names):
         param_dict[param_name] = np.expand_dims(arr[ii:ii + 1], 0)
     return param_dict
+
+
+def resolve_sigmas(parameter_names: List[float],
+                   sigma_proposals: Optional[Dict] = None,
+                   bounds: Optional[Dict] = None) -> List:
+    """Map dictionary of sigma_proposals into a list order as parameter_names.
+
+    Parameters
+    ----------
+    parameter_names: List[float]
+        names of the parameters
+    sigma_proposals: Dict
+        non-negative standard deviations for each dimension
+        {'parameter_name': float}
+    bounds : dict, optional
+        the region where to estimate the posterior for each parameter in
+        model.parameters
+        `{'parameter_name':(lower, upper), ... }
+
+    Returns
+    -------
+    List
+       list of sigma_proposals in the same order than in parameter_names
+
+    """
+    if sigma_proposals is None:
+        sigma_proposals = []
+        for bound in bounds:
+            length_interval = bound[1] - bound[0]
+            sigma_proposals.append(length_interval / 10)
+    elif isinstance(sigma_proposals, dict):
+        errmsg = "sigma_proposals' keys have to be identical to " \
+                    "target_model.parameter_names."
+        if len(sigma_proposals) is not len(parameter_names):
+            raise ValueError(errmsg)
+        try:
+            sigma_proposals = [sigma_proposals[x] for x in parameter_names]
+        except ValueError:
+            print(parameter_names)
+    else:
+        raise ValueError("If provided, sigma_proposals need to be input as a dict.")
+
+    return sigma_proposals

--- a/elfi/methods/utils.py
+++ b/elfi/methods/utils.py
@@ -457,19 +457,19 @@ def flat_array_to_dict(names, arr):
     return param_dict
 
 
-def resolve_sigmas(parameter_names: List[float],
+def resolve_sigmas(parameter_names: List[str],
                    sigma_proposals: Optional[Dict] = None,
                    bounds: Optional[Dict] = None) -> List:
     """Map dictionary of sigma_proposals into a list order as parameter_names.
 
     Parameters
     ----------
-    parameter_names: List[float]
+    parameter_names: List[str]
         names of the parameters
     sigma_proposals: Dict
         non-negative standard deviations for each dimension
         {'parameter_name': float}
-    bounds : dict, optional
+    bounds : Dict, optional
         the region where to estimate the posterior for each parameter in
         model.parameters
         `{'parameter_name':(lower, upper), ... }

--- a/tests/unit/test_methods.py
+++ b/tests/unit/test_methods.py
@@ -100,7 +100,10 @@ def test_BOLFI_short(ma2, distribution_test):
     assert res_sampling_nuts.samples_array.shape[1] == 2
     assert len(res_sampling_nuts.samples_array) == n_samples // 2 * n_chains
 
-    res_sampling_metropolis = bolfi.sample(n_samples, n_chains=n_chains, algorithm='metropolis',sigma_proposals=np.ones(2))
+    res_sampling_metropolis = bolfi.sample(n_samples,
+                                           n_chains=n_chains,
+                                           algorithm='metropolis',
+                                           sigma_proposals={'t1': 0.2, 't2': 0.1})
     assert res_sampling_metropolis.samples_array.shape[1] == 2
     assert len(res_sampling_metropolis.samples_array) == n_samples // 2 * n_chains
 


### PR DESCRIPTION
#### Summary:
Earlier `sigma_proposals` to be used in `metropolis` were input as a list. To make sure that standard deviations are assigned correctly to parameter dimensions, input format has been changed from List to Dict.

#### Please make sure

- [x] You have updated the CHANGELOG.rst
- [x] You have provided a short summary of your changes (see previous section)
- [x] You have listed the copyright holder for the work you are submitting (see next section)

If your contribution adds, removes or somehow changes the functional behavior of the package, please check that

- [x] You have included or updated all the relevant documentation 
- [x] You have added appropriate unit tests to ensure the new features behave as expected

and the proposed changes pass all unit tests (check step 6 of CONTRIBUTING.rst for details)

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): @hpesonen 

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD3 (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
