### PR TITLE
Add additive acquisition cost

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,7 @@
 Changelog
 =========
 
+- Add option to use additive acquisition cost in LCBSC
 - Change sigma_proposals-input in metropolis from list to dict
 - Fix is_array in utils
 - Fix acq_noise_var-bug in acquisition.py. Influenced BOLFI.

--- a/elfi/methods/bo/acquisition.py
+++ b/elfi/methods/bo/acquisition.py
@@ -212,6 +212,9 @@ class LCBSC(AcquisitionBase):
         super(LCBSC, self).__init__(*args, **kwargs)
         self.name = 'lcbsc'
         self.label_fn = 'Confidence Bound'
+
+        if additive_cost is not None and not isinstance(additive_cost, CostFunction):
+            raise TypeError("Additive cost must be type CostFunction.")
         self.additive_cost = additive_cost
 
     @property

--- a/elfi/methods/bo/acquisition.py
+++ b/elfi/methods/bo/acquisition.py
@@ -7,7 +7,7 @@ import scipy.linalg as sl
 import scipy.stats as ss
 
 import elfi.methods.mcmc as mcmc
-from elfi.methods.bo.utils import Function, minimize
+from elfi.methods.bo.utils import CostFunction, minimize
 
 logger = logging.getLogger(__name__)
 
@@ -200,8 +200,8 @@ class LCBSC(AcquisitionBase):
         delta: float, optional
             In between (0, 1). Default is 1/exploration_rate. If given, overrides the
             exploration_rate.
-        additive_cost: Function, optional
-            Function output is added to the base acquisition value.
+        additive_cost: CostFunction, optional
+            Cost function output is added to the base acquisition value.
 
         """
         if delta is not None:

--- a/elfi/methods/bo/utils.py
+++ b/elfi/methods/bo/utils.py
@@ -109,15 +109,53 @@ def minimize(fun,
 
     return locs[ind_min], vals[ind_min]
 
-class Function():
+class CostFunction():
+    """Convenience class for modelling acquisition costs. """
 
     def __init__(self, function, gradient, scale=1):
+        """Initialise CostFunction.
+
+        Parameters
+        ----------
+        function : callable
+            Function that returns cost function value.
+        gradient : callable
+            Function that returns cost function gradient.
+        scale : float, optional
+            Cost function is multiplied with scale.
+        """
         self.function=function
         self.gradient=gradient
         self.scale=scale
 
     def evaluate(self, x):
-        return self.scale*self.function(x).reshape(-1,1)
+        """Returns cost function value evaluated at x.
+
+        Parameters
+        ----------
+        x : np.ndarray, shape: (input_dim,) or (n, input_dim)
+
+        Returns
+        -------
+        f : np.ndarray, shape: (n, 1)
+
+        """
+        x = np.atleast_2d(x)
+        n, input_dim = x.shape
+        return self.scale * self.function(x).reshape(n, 1)
 
     def evaluate_gradient(self, x):
-        return self.scale*self.gradient(x).reshape(1,-1)
+        """Returns cost function gradient evaluated at x.
+
+        Parameters
+        ----------
+        x : np.ndarray, shape: (input_dim,) or (n, input_dim)
+
+        Returns
+        -------
+        df_dx : np.ndarray, shape: (n, input_dim)
+
+        """
+        x = np.atleast_2d(x)
+        n, input_dim = x.shape
+        return self.scale * self.gradient(x).reshape(n, input_dim)

--- a/elfi/methods/bo/utils.py
+++ b/elfi/methods/bo/utils.py
@@ -110,7 +110,7 @@ def minimize(fun,
     return locs[ind_min], vals[ind_min]
 
 
-class CostFunction():
+class CostFunction:
     """Convenience class for modelling acquisition costs."""
 
     def __init__(self, function, gradient, scale=1):
@@ -139,7 +139,7 @@ class CostFunction():
 
         Returns
         -------
-        f : np.ndarray, shape: (n, 1)
+        np.ndarray, shape: (n, 1)
 
         """
         x = np.atleast_2d(x)
@@ -155,7 +155,7 @@ class CostFunction():
 
         Returns
         -------
-        df_dx : np.ndarray, shape: (n, input_dim)
+        np.ndarray, shape: (n, input_dim)
 
         """
         x = np.atleast_2d(x)

--- a/elfi/methods/bo/utils.py
+++ b/elfi/methods/bo/utils.py
@@ -109,8 +109,9 @@ def minimize(fun,
 
     return locs[ind_min], vals[ind_min]
 
+
 class CostFunction():
-    """Convenience class for modelling acquisition costs. """
+    """Convenience class for modelling acquisition costs."""
 
     def __init__(self, function, gradient, scale=1):
         """Initialise CostFunction.
@@ -123,13 +124,14 @@ class CostFunction():
             Function that returns cost function gradient.
         scale : float, optional
             Cost function is multiplied with scale.
+
         """
-        self.function=function
-        self.gradient=gradient
-        self.scale=scale
+        self.function = function
+        self.gradient = gradient
+        self.scale = scale
 
     def evaluate(self, x):
-        """Returns cost function value evaluated at x.
+        """Return cost function value evaluated at x.
 
         Parameters
         ----------
@@ -145,7 +147,7 @@ class CostFunction():
         return self.scale * self.function(x).reshape(n, 1)
 
     def evaluate_gradient(self, x):
-        """Returns cost function gradient evaluated at x.
+        """Return cost function gradient evaluated at x.
 
         Parameters
         ----------

--- a/elfi/methods/bo/utils.py
+++ b/elfi/methods/bo/utils.py
@@ -108,3 +108,16 @@ def minimize(fun,
         locs_out[i] = np.clip(locs_out[i], *bounds[i])
 
     return locs[ind_min], vals[ind_min]
+
+class Function():
+
+    def __init__(self, function, gradient, scale=1):
+        self.function=function
+        self.gradient=gradient
+        self.scale=scale
+
+    def evaluate(self, x):
+        return self.scale*self.function(x).reshape(-1,1)
+
+    def evaluate_gradient(self, x):
+        return self.scale*self.gradient(x).reshape(1,-1)

--- a/elfi/methods/inference/bolfire.py
+++ b/elfi/methods/inference/bolfire.py
@@ -10,8 +10,8 @@ import elfi.methods.mcmc as mcmc
 from elfi.classifiers.classifier import Classifier, LogisticRegression
 from elfi.loader import get_sub_seed
 from elfi.methods.bo.acquisition import LCBSC, AcquisitionBase
-from elfi.methods.bo.utils import CostFunction
 from elfi.methods.bo.gpy_regression import GPyRegression
+from elfi.methods.bo.utils import CostFunction
 from elfi.methods.inference.parameter_inference import ParameterInference
 from elfi.methods.posteriors import BOLFIREPosterior
 from elfi.methods.results import BOLFIRESample

--- a/elfi/methods/inference/bolfire.py
+++ b/elfi/methods/inference/bolfire.py
@@ -10,7 +10,7 @@ import elfi.methods.mcmc as mcmc
 from elfi.classifiers.classifier import Classifier, LogisticRegression
 from elfi.loader import get_sub_seed
 from elfi.methods.bo.acquisition import LCBSC, AcquisitionBase
-from elfi.methods.bo.utils import Function
+from elfi.methods.bo.utils import CostFunction
 from elfi.methods.bo.gpy_regression import GPyRegression
 from elfi.methods.inference.parameter_inference import ParameterInference
 from elfi.methods.posteriors import BOLFIREPosterior
@@ -94,7 +94,7 @@ class BOLFIRE(ParameterInference):
         self.target_model = self._resolve_target_model(target_model)
 
         # Define acquisition cost
-        self.cost=Function(self.prior.logpdf, self.prior.gradient_logpdf, scale=-1)
+        self.cost = CostFunction(self.prior.logpdf, self.prior.gradient_logpdf, scale=-1)
 
         # Initialize BO
         self.n_initial_evidence = self._resolve_n_initial_evidence(n_initial_evidence)

--- a/elfi/methods/inference/bolfire.py
+++ b/elfi/methods/inference/bolfire.py
@@ -10,6 +10,7 @@ import elfi.methods.mcmc as mcmc
 from elfi.classifiers.classifier import Classifier, LogisticRegression
 from elfi.loader import get_sub_seed
 from elfi.methods.bo.acquisition import LCBSC, AcquisitionBase
+from elfi.methods.bo.utils import Function
 from elfi.methods.bo.gpy_regression import GPyRegression
 from elfi.methods.inference.parameter_inference import ParameterInference
 from elfi.methods.posteriors import BOLFIREPosterior
@@ -91,6 +92,9 @@ class BOLFIRE(ParameterInference):
 
         # Initialize GP regression
         self.target_model = self._resolve_target_model(target_model)
+
+        # Define acquisition cost
+        self.cost=Function(self.prior.logpdf, self.prior.gradient_logpdf, scale=-1)
 
         # Initialize BO
         self.n_initial_evidence = self._resolve_n_initial_evidence(n_initial_evidence)
@@ -437,7 +441,7 @@ class BOLFIRE(ParameterInference):
                          noise_var=self.acq_noise_var,
                          exploration_rate=self.exploration_rate,
                          seed=self.seed,
-                         include_prior=True)
+                         additive_cost=self.cost)
         if isinstance(acquisition_method, AcquisitionBase):
             return acquisition_method
         raise TypeError('acquisition_method must be an instance of AcquisitionBase.')

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -6,7 +6,7 @@ import scipy.stats as ss
 
 import elfi
 from elfi.examples.ma2 import get_model
-from elfi.methods.bo.utils import minimize, stochastic_optimization
+from elfi.methods.bo.utils import CostFunction, minimize, stochastic_optimization
 from elfi.methods.density_ratio_estimation import DensityRatioEstimation
 from elfi.methods.utils import (GMDistribution, normalize_weights, numgrad, numpy_to_python_type,
                                 sample_object_to_dict, weighted_sample_quantile, weighted_var)
@@ -282,3 +282,21 @@ class TestDensityRatioEstimation:
 
         assert np.max(np.abs(test_w - test_w_estim)) < 0.1
         assert np.abs(np.max(test_w) - densratio.max_ratio()) < 0.1
+
+class TestCostFunction:
+
+    def test_evaluate(self):
+        def fun(x):
+            return x[0]**2 + (x[1] - 1)**4
+        
+        cost = CostFunction(elfi.tools.vectorize(fun), None, scale=10)
+        x = np.array([0.5, 0.5])
+        assert np.isclose(10 * fun(x), cost.evaluate(x))
+
+    def test_evaluate_gradient(self):
+        def grad(x):
+            return np.array([2 * x[0], 4 * (x[1] - 1)**3])
+
+        cost = CostFunction(None, elfi.tools.vectorize(grad), scale=10)
+        x = np.array([0.5, 0.5])
+        assert np.allclose(10 * grad(x), cost.evaluate_gradient(x))


### PR DESCRIPTION
#### Summary:
Added `CostFunction` class to represent acquisition costs with gradient, and introduced option to use additive costs in LCBSC. The new feature substitutes the option to add negative log-prior values to acquisition scores in LCBSC, and BOLFIRE was updated to use the new feature.

#### Please make sure

- [x] You have updated the CHANGELOG.rst
- [x] You have provided a short summary of your changes (see previous section)
- [x] You have listed the copyright holder for the work you are submitting (see next section)

If your contribution adds, removes or somehow changes the functional behavior of the package, please check that

- [x] You have included or updated all the relevant documentation 
- [x] You have added appropriate unit tests to ensure the new features behave as expected

and the proposed changes pass all unit tests (check step 6 of CONTRIBUTING.rst for details)

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD3 (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
