### PR TITLE
Update BOLFIRE to run simulations in batches

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,7 @@
 Changelog
 =========
 
+- Use batch system to run simulations in BOLFIRE
 - Use `target_model.parameter_names` from instead of `model.parameter_names` in `BOLFIRE`
 - Extract BO results using `target_model.parameter_names` from instead of `model.parameter_names`
 - Update tox.ini

--- a/elfi/methods/inference/bolfire.py
+++ b/elfi/methods/inference/bolfire.py
@@ -109,6 +109,7 @@ class BOLFIRE(ParameterInference):
         self.classifier_attributes = []
 
         # Initialize data collection
+        self.random_state = np.random.RandomState(self.seed)
         self._init_round()
 
     @property
@@ -421,9 +422,7 @@ class BOLFIRE(ParameterInference):
         # Set new parameter values
         if self.n_evidence < self.n_initial_evidence:
             # Sample parameter values from the model priors
-            seed = self.seed + self.n_evidence
-            random_state = np.random.RandomState(seed)
-            self._params = self.prior.rvs(1, random_state=random_state)
+            self._params = self.prior.rvs(1, random_state=self.random_state)
         else:
             # Acquire parameter values from the acquisition function
             t = self.n_evidence - self.n_initial_evidence

--- a/tests/unit/test_bolfire_unit.py
+++ b/tests/unit/test_bolfire_unit.py
@@ -52,12 +52,8 @@ def test_generate_marginal(bolfire_method):
     assert bolfire_method._generate_marginal().shape == (10, 10)
 
 
-def test_generate_likelihood(bolfire_method, parameter_values):
-    assert bolfire_method._generate_likelihood(parameter_values).shape == (10, 10)
-
-
 def test_generate_training_data(bolfire_method, parameter_values):
-    likelihood = bolfire_method._generate_likelihood(parameter_values)
+    likelihood = np.random.rand(10, 10)
     X, y = bolfire_method._generate_training_data(likelihood, bolfire_method.marginal)
     assert X.shape == (20, 10)
     assert y.shape == (20,)


### PR DESCRIPTION
#### Summary:

updated likelihood data generation in BOLFIRE so that it uses the batch system in ELFI. the current version in ELFI uses `model.generate` to run `n_training_data` simulations with selected parameter values. the new version updates parameter values between data collection rounds and uses the batch system to run the `n_training_data` simulations needed to complete each round. the simulations are carried out in `batch_size` batches that can be run in parallel. `n_training_data` must be a multiple of `batch_size`.

notes: 
- the current new implementation does not allow running simulations with several parameter values at the same time. this means that new parameter values are not selected and new batches are not submitted until the current parameter values have been used to run `n_training_data` simulations and the data from those simulations has been used in a model update. 
- `model.generate` is still used to generate marginal data

#### Please make sure

- [x] You have updated the CHANGELOG.rst
- [x] You have provided a short summary of your changes (see previous section)
- [x] You have listed the copyright holder for the work you are submitting (see next section)

If your contribution adds, removes or somehow changes the functional behavior of the package, please check that

- [ ] You have included or updated all the relevant documentation 
- [ ] You have added appropriate unit tests to ensure the new features behave as expected

and the proposed changes pass all unit tests (check step 6 of CONTRIBUTING.rst for details)

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD3 (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
