### PR TITLE
Fix generate outputs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,7 @@
 Changelog
 =========
 
+- Fix default outputs in generate
 - Add docstring description to ARCH-model
 - Make MAP estimates calculation in BOLFIRE optional and based on log-posterior
 - Use batch system to run simulations in BOLFIRE

--- a/elfi/model/elfi_model.py
+++ b/elfi/model/elfi_model.py
@@ -277,7 +277,7 @@ class ElfiModel(GraphicalModel):
 
         """
         if outputs is None:
-            outputs = self.source_net.nodes()
+            outputs = list(self.source_net.nodes())
         elif isinstance(outputs, str):
             outputs = [outputs]
         if not isinstance(outputs, list):

--- a/tests/unit/test_elfi_model.py
+++ b/tests/unit/test_elfi_model.py
@@ -20,6 +20,17 @@ def test_generate(ma2):
 
 
 @pytest.mark.usefixtures('with_all_clients')
+def test_generate_outputs(ma2):
+    n_gen = 10
+
+    res = ma2.generate(n_gen)
+
+    assert 'd' in res
+    assert res['d'].shape[0] == n_gen
+    assert res['d'].ndim == 1
+
+
+@pytest.mark.usefixtures('with_all_clients')
 def test_observed():
     true_params = [.6, .2]
     m = ema2.get_model(100, true_params=true_params)


### PR DESCRIPTION
#### Summary:

`outputs` is an optional input to the elfi model `generate` function, but the current version returns an error when called without `outputs`. this is because the default option is broken: `generate` tries to use `source_net.nodes` which is a nodeview instance when a list is needed. here it is converted.

i also added a new test because the current set did not cover the broken feature and it can break when `source_net` is updated. `source_net.nodes` was a list in the networkx version that was in use earlier.

#### Please make sure

- [x] You have updated the CHANGELOG.rst
- [x] You have provided a short summary of your changes (see previous section)
- [x] You have listed the copyright holder for the work you are submitting (see next section)

If your contribution adds, removes or somehow changes the functional behavior of the package, please check that

- [ ] You have included or updated all the relevant documentation 
- [ ] You have added appropriate unit tests to ensure the new features behave as expected

and the proposed changes pass all unit tests (check step 6 of CONTRIBUTING.rst for details)

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD3 (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
