### PR TITLE
Fix simulator node observed

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,7 @@
 Changelog
 =========
 
+- Fix the observed property in simulator nodes
 - Add docstring description to ARCH-model
 - Make MAP estimates calculation in BOLFIRE optional and based on log-posterior
 - Use batch system to run simulations in BOLFIRE

--- a/elfi/executor.py
+++ b/elfi/executor.py
@@ -107,6 +107,9 @@ class Executor:
         # Filter those output nodes who have an operation to run
         needed = tuple(sorted(node for node in output_nodes if 'operation' in G.nodes[node]))
 
+        if len(needed) == 0:
+            return []
+
         if needed not in cache:
             # Resolve the nodes that need to be executed in the graph
             nodes_to_execute = set(needed)


### PR DESCRIPTION
#### Summary:

simulator nodes in the ELFI model have a property called `observed` which is defined [here](https://github.com/elfi-dev/elfi/blob/dev/elfi/model/elfi_model.py#L742-L746). however the computation fails because `get_execution_order` cannot handle the case that no nodes need to be executed.

#### Example:

```python
import elfi.examples.ma2
model = elfi.examples.ma2.get_model()
model['MA2'].observed
```

#### Please make sure

- [x] You have updated the CHANGELOG.rst
- [x] You have provided a short summary of your changes (see previous section)
- [x] You have listed the copyright holder for the work you are submitting (see next section)

If your contribution adds, removes or somehow changes the functional behavior of the package, please check that

- [ ] You have included or updated all the relevant documentation 
- [ ] You have added appropriate unit tests to ensure the new features behave as expected

and the proposed changes pass all unit tests (check step 6 of CONTRIBUTING.rst for details)

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD3 (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
