### PR TITLE
Fix parameter order in model prior

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,7 @@
 Changelog
 =========
 
+- Add parameter names as an optional input in model prior and fix the parameter order in priors used in BOLFI and BOLFIRE
 - Add feature names as an optional input and make training data size a required input in BOLFIRE
 - Fix the observed property in simulator nodes
 - Fix default outputs in generate

--- a/elfi/methods/inference/bolfi.py
+++ b/elfi/methods/inference/bolfi.py
@@ -99,9 +99,9 @@ class BayesianOptimization(ParameterInference):
 
         self.batches_per_acquisition = batches_per_acquisition or self.max_parallel_batches
 
+        prior = ModelPrior(self.model, parameter_names=self.target_model.parameter_names)
         self.acquisition_method = acquisition_method or LCBSC(self.target_model,
-                                                              prior=ModelPrior(
-                                                                  self.model),
+                                                              prior=prior,
                                                               noise_var=acq_noise_var,
                                                               exploration_rate=exploration_rate,
                                                               seed=self.seed)
@@ -456,7 +456,8 @@ class BOLFI(BayesianOptimization):
             raise ValueError(
                 'Model is not fitted yet, please see the `fit` method.')
 
-        return BolfiPosterior(self.target_model, threshold=threshold, prior=ModelPrior(self.model))
+        prior = ModelPrior(self.model, parameter_names=self.target_model.parameter_names)
+        return BolfiPosterior(self.target_model, threshold=threshold, prior=prior)
 
     def sample(self,
                n_samples,

--- a/elfi/methods/inference/bolfire.py
+++ b/elfi/methods/inference/bolfire.py
@@ -85,7 +85,6 @@ class BOLFIRE(ParameterInference):
         self.marginal = self._resolve_marginal(marginal, seed_marginal)
         self.classifier = self._resolve_classifier(classifier)
         self.observed = self._get_observed_feature_values(self.model, self.feature_names)
-        self.prior = ModelPrior(self.model)
 
         # TODO: write resolvers for the attributes below
         self.bounds = bounds
@@ -95,6 +94,7 @@ class BOLFIRE(ParameterInference):
 
         # Initialize GP regression
         self.target_model = self._resolve_target_model(target_model)
+        self.prior = ModelPrior(self.model, parameter_names=self.target_model.parameter_names)
 
         # Define acquisition cost
         self.cost = CostFunction(self.prior.logpdf, self.prior.gradient_logpdf, scale=-1)

--- a/elfi/model/extensions.py
+++ b/elfi/model/extensions.py
@@ -116,18 +116,30 @@ class ScipyLikeDistribution:
 # TODO: could use some optimization
 # TODO: support the case where some priors are multidimensional
 class ModelPrior:
-    """Construct a joint prior distribution over all the parameter nodes in `ElfiModel`."""
+    """Construct a joint prior distribution over all or selected parameter nodes in `ElfiModel`."""
 
-    def __init__(self, model):
+    def __init__(self, model, parameter_names=None):
         """Initialize a ModelPrior.
 
         Parameters
         ----------
         model : ElfiModel
+        parameter_names : list, optional
+            Parameters included in the prior and their order. Default model.parameter_names.
 
         """
         model = model.copy()
-        self.parameter_names = model.parameter_names
+
+        if parameter_names is None:
+            self.parameter_names = model.parameter_names
+        elif isinstance(parameter_names, list):
+            for param in parameter_names:
+                if param not in model.parameter_names:
+                    raise ValueError(f"Parameter \'{param}\' not found in model parameters.")
+            self.parameter_names = parameter_names
+        else:
+            raise ValueError("parameter_names must be a list of strings.")
+
         self.dim = len(self.parameter_names)
         self.client = Client()
 


### PR DESCRIPTION
#### Summary:

update `ModelPrior` to allow control over parameter order and update the model priors used in BOLFI and BOLFIRE to use the parameter order used in their `target_model`

- what was the problem:

BOLFI and BOLFIRE use a target model to represent dependencies between parameter vectors and a response variable. previous updates #402 and #403  addressed the issue that BOLFI and BOLFIRE converted parameter dictionaries into parameter vectors based on `self.parameter_names` which corresponds to `self.model.parameter_names`. parameters presented to the target model are now ordered based on `self.target_model.parameter_names`. however both methods also use a `ModelPrior` instance that orders parameter values based on `self.model.parameter_names`. this could be a problem because BOLFI and BOLFIRE assume that the target model and prior operate on the same parameter vectors. this is seen for example in posterior probabilities calculation.

#### Please make sure

- [x] You have updated the CHANGELOG.rst
- [x] You have provided a short summary of your changes (see previous section)
- [x] You have listed the copyright holder for the work you are submitting (see next section)

If your contribution adds, removes or somehow changes the functional behavior of the package, please check that

- [ ] You have included or updated all the relevant documentation 
- [ ] You have added appropriate unit tests to ensure the new features behave as expected

and the proposed changes pass all unit tests (check step 6 of CONTRIBUTING.rst for details)

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD3 (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
