### PR TITLE
Modify lv priors

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,7 @@
 Changelog
 =========
 
+- Modify Lotka-Volterra model's priors as many methods do not support discrete random variables.
 - Fix linting in `arch.py`
 - Add summary statistics to Lotka-Volterra model
 - Add boolean `observation_noise` option to `lotka_volterra`

--- a/elfi/examples/lotka_volterra.py
+++ b/elfi/examples/lotka_volterra.py
@@ -74,7 +74,7 @@ def lotka_volterra(r1, r2, r3, prey_init=50, predator_init=100, sigma=0., n_obs=
 
     n_full = 20000
     stock = np.empty((batch_size, n_full, 2), dtype=np.int32)
-    # As we use approximate continuous priors for prey_init and 
+    # As we use approximate continuous priors for prey_init and
     # predator_init, we'll round them down to closest integers
     stock[:, 0, 0] = np.floor(prey_init)
     stock[:, 0, 1] = np.floor(predator_init)
@@ -194,8 +194,6 @@ def get_model(n_obs=50, true_params=None, observation_noise=False, seed_obs=None
         elfi.Prior(ExpUniform, -6., 2., model=m, name='r1'),
         elfi.Prior(ExpUniform, -6., 2., model=m, name='r2'),  # easily kills populations
         elfi.Prior(ExpUniform, -6., 2., model=m, name='r3'),
-        # elfi.Prior('poisson', 50, model=m, name='prey0'),
-        # elfi.Prior('poisson', 100, model=m, name='predator0')
         elfi.Prior('normal', 50, np.sqrt(50), model=m, name='prey0'),
         elfi.Prior('normal', 100, np.sqrt(100), model=m, name='predator0')
     ]

--- a/elfi/examples/lotka_volterra.py
+++ b/elfi/examples/lotka_volterra.py
@@ -74,8 +74,10 @@ def lotka_volterra(r1, r2, r3, prey_init=50, predator_init=100, sigma=0., n_obs=
 
     n_full = 20000
     stock = np.empty((batch_size, n_full, 2), dtype=np.int32)
-    stock[:, 0, 0] = prey_init
-    stock[:, 0, 1] = predator_init
+    # As we use approximate continuous priors for prey_init and 
+    # predator_init, we'll round them down to closest integers
+    stock[:, 0, 0] = np.floor(prey_init)
+    stock[:, 0, 1] = np.floor(predator_init)
     stoichiometry = np.array([[1, 0], [-1, 1], [0, -1], [0, 0]], dtype=np.int32)
     times = np.empty((batch_size, n_full))
     times[:, 0] = 0
@@ -192,8 +194,10 @@ def get_model(n_obs=50, true_params=None, observation_noise=False, seed_obs=None
         elfi.Prior(ExpUniform, -6., 2., model=m, name='r1'),
         elfi.Prior(ExpUniform, -6., 2., model=m, name='r2'),  # easily kills populations
         elfi.Prior(ExpUniform, -6., 2., model=m, name='r3'),
-        elfi.Prior('poisson', 50, model=m, name='prey0'),
-        elfi.Prior('poisson', 100, model=m, name='predator0')
+        # elfi.Prior('poisson', 50, model=m, name='prey0'),
+        # elfi.Prior('poisson', 100, model=m, name='predator0')
+        elfi.Prior('normal', 50, np.sqrt(50), model=m, name='prey0'),
+        elfi.Prior('normal', 100, np.sqrt(100), model=m, name='predator0')
     ]
 
     if observation_noise:


### PR DESCRIPTION
#### Summary:
Changed poisson priors in Lotka-Volterra-model to approximate Gaussians, because most inference methods in elfi do not support discrete priors.

#### Please make sure

- [x] You have updated the CHANGELOG.rst
- [x] You have provided a short summary of your changes (see previous section)
- [x] You have listed the copyright holder for the work you are submitting (see next section)

If your contribution adds, removes or somehow changes the functional behavior of the package, please check that

- [ ] You have included or updated all the relevant documentation 
- [ ] You have added appropriate unit tests to ensure the new features behave as expected

and the proposed changes pass all unit tests (check step 6 of CONTRIBUTING.rst for details)

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company): @hpesonen 

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD3 (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
