### PR TITLE
Fix acquisition index in state plot

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,7 @@
 Changelog
 =========
 
+- Fix acquisition index in state plot
 - Reformat `summary()` for `Sample(ParameterInferenceResult)`
 - Fix linting in `arch.py`
 - Add summary statistics to Lotka-Volterra model

--- a/elfi/methods/inference/bolfi.py
+++ b/elfi/methods/inference/bolfi.py
@@ -326,7 +326,7 @@ class BayesianOptimization(ParameterInference):
             if len(gp.X) > 1:
                 f.axes[1].scatter(*point, color='red')
 
-        displays = [gp._gp]
+        displays = [gp.instance]
 
         if options.get('interactive'):
             from IPython import display
@@ -338,8 +338,9 @@ class BayesianOptimization(ParameterInference):
         # Update
         visin._update_interactive(displays, options)
 
+        acq_index = self._get_acquisition_index(self.state['n_batches'])
         def acq(x):
-            return self.acquisition_method.evaluate(x, len(gp.X))
+            return self.acquisition_method.evaluate(x, acq_index)
 
         # Draw the acquisition surface
         visin.draw_contour(


### PR DESCRIPTION
#### Summary:

- update `plot_state` to calculate acquisition scores based on the same acquisition index that is used in `prepare_new_batch`.
- update `plot_state` to use `target_model.instance` so that it does not access `target_model._gp` which looks private.

#### Please make sure

- [x] You have updated the CHANGELOG.rst
- [x] You have provided a short summary of your changes (see previous section)
- [x] You have listed the copyright holder for the work you are submitting (see next section)

If your contribution adds, removes or somehow changes the functional behavior of the package, please check that

- [ ] You have included or updated all the relevant documentation 
- [ ] You have added appropriate unit tests to ensure the new features behave as expected

and the proposed changes pass all unit tests (check step 6 of CONTRIBUTING.rst for details)

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD3 (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
