### PR TITLE
Release v0.8.4

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,7 @@
 Changelog
 =========
 
+- Fix default outputs in generate
 - Add docstring description to ARCH-model
 - Make MAP estimates calculation in BOLFIRE optional and based on log-posterior
 - Use batch system to run simulations in BOLFIRE

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,7 @@
 Changelog
 =========
 
+- Fix linting in `arch.py`
 - Add summary statistics to Lotka-Volterra model
 - Add boolean `observation_noise` option to `lotka_volterra`
 - Add parameter names as an optional input in model prior and fix the parameter order in priors used in BOLFI and BOLFIRE

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,7 @@
 Changelog
 =========
 
+- Use batch system to run simulations in BOLFIRE
 - Use `target_model.parameter_names` from instead of `model.parameter_names` in `BOLFIRE`
 - Extract BO results using `target_model.parameter_names` from instead of `model.parameter_names`
 - Update tox.ini

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,7 @@
 Changelog
 =========
 
+- Modify Lotka-Volterra model's priors as many methods do not support discrete random variables.
 - Fix acquisition index in state plot
 - Reformat `summary()` for `Sample(ParameterInferenceResult)`
 - Fix linting in `arch.py`

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,7 @@
 Changelog
 =========
 
+- Reformat `summary()` for `Sample(ParameterInferenceResult)`
 - Fix linting in `arch.py`
 - Add summary statistics to Lotka-Volterra model
 - Add boolean `observation_noise` option to `lotka_volterra`

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,7 @@
 Changelog
 =========
 
+- Add feature names as an optional input and make training data size a required input in BOLFIRE
 - Fix the observed property in simulator nodes
 - Fix default outputs in generate
 - Add docstring description to ARCH-model

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,7 +1,7 @@
 Changelog
 =========
 
-
+- Add summary statistics to Lotka-Volterra model
 - Add boolean `observation_noise` option to `lotka_volterra`
 - Add parameter names as an optional input in model prior and fix the parameter order in priors used in BOLFI and BOLFIRE
 - Add feature names as an optional input and make training data size a required input in BOLFIRE

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,7 @@
 Changelog
 =========
 
+- Use `target_model.parameter_names` from instead of `model.parameter_names` in `BOLFIRE`
 - Extract BO results using `target_model.parameter_names` from instead of `model.parameter_names`
 - Update tox.ini
 - Add option to use additive acquisition cost in LCBSC

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,7 @@
 Changelog
 =========
 
+- Extract BO results using `target_model.parameter_names` from instead of `model.parameter_names`
 - Update tox.ini
 - Add option to use additive acquisition cost in LCBSC
 - Change sigma_proposals-input in metropolis from list to dict

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,7 @@
 Changelog
 =========
 
+- Add docstring description to ARCH-model
 - Make MAP estimates calculation in BOLFIRE optional and based on log-posterior
 - Use batch system to run simulations in BOLFIRE
 - Use `target_model.parameter_names` from instead of `model.parameter_names` in `BOLFIRE`

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,7 @@
 Changelog
 =========
 
+- Change sigma_proposals-input in metropolis from list to dict
 - Fix is_array in utils
 - Fix acq_noise_var-bug in acquisition.py. Influenced BOLFI.
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,7 @@
 Changelog
 =========
 
+- Fix the observed property in simulator nodes
 - Fix default outputs in generate
 - Add docstring description to ARCH-model
 - Make MAP estimates calculation in BOLFIRE optional and based on log-posterior

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,7 @@
 Changelog
 =========
 
+- Add option to use additive acquisition cost in LCBSC
 - Change sigma_proposals-input in metropolis from list to dict
 - Fix is_array in utils
 - Fix acq_noise_var-bug in acquisition.py. Influenced BOLFI.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,8 @@
 Changelog
 =========
 
+
+- Add boolean `observation_noise` option to `lotka_volterra`
 - Add parameter names as an optional input in model prior and fix the parameter order in priors used in BOLFI and BOLFIRE
 - Add feature names as an optional input and make training data size a required input in BOLFIRE
 - Fix the observed property in simulator nodes

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,7 @@
 Changelog
 =========
 
+- Add parameter names as an optional input in model prior and fix the parameter order in priors used in BOLFI and BOLFIRE
 - Add feature names as an optional input and make training data size a required input in BOLFIRE
 - Fix the observed property in simulator nodes
 - Fix default outputs in generate

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,7 @@
 Changelog
 =========
 
+- Fix is_array in utils
 - Fix acq_noise_var-bug in acquisition.py. Influenced BOLFI.
 
 0.8.3 (2021-02-17)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,8 @@
 Changelog
 =========
 
+- Fix acq_noise_var-bug in acquisition.py. Influenced BOLFI.
+
 0.8.3 (2021-02-17)
 ------------------
 - Add a new inference method: BOLFIRE

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,8 @@
 Changelog
 =========
 
+0.8.4 (2021-06-13)
+------------------
 - Modify Lotka-Volterra model's priors as many methods do not support discrete random variables.
 - Fix acquisition index in state plot
 - Reformat `summary()` for `Sample(ParameterInferenceResult)`

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,7 @@
 Changelog
 =========
 
+- Fix acquisition index in state plot
 - Reformat `summary()` for `Sample(ParameterInferenceResult)`
 - Fix linting in `arch.py`
 - Add summary statistics to Lotka-Volterra model

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,7 @@
 Changelog
 =========
 
+- Make MAP estimates calculation in BOLFIRE optional and based on log-posterior
 - Use batch system to run simulations in BOLFIRE
 - Use `target_model.parameter_names` from instead of `model.parameter_names` in `BOLFIRE`
 - Extract BO results using `target_model.parameter_names` from instead of `model.parameter_names`

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,7 @@
 Changelog
 =========
 
+- Update tox.ini
 - Add option to use additive acquisition cost in LCBSC
 - Change sigma_proposals-input in metropolis from list to dict
 - Fix is_array in utils

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,3 @@
 recursive-include elfi/examples/cpp *.txt *.cpp Makefile
+include docs/description.rst
+include requirements.txt

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-**Version 0.8.3 released!** See the [CHANGELOG](CHANGELOG.rst) and [notebooks](https://github.com/elfi-dev/notebooks).
+**Version 0.8.4 released!** See the [CHANGELOG](CHANGELOG.rst) and [notebooks](https://github.com/elfi-dev/notebooks).
 
 <img src="https://raw.githubusercontent.com/elfi-dev/elfi/dev/docs/logos/elfi_logo_text_nobg.png" width="200" />
 

--- a/docs/usage/BOLFI.rst
+++ b/docs/usage/BOLFI.rst
@@ -92,7 +92,7 @@ surface is updated after each batch (especially so if the noise is 0!).
 .. code:: ipython3
 
     bolfi = elfi.BOLFI(log_d, batch_size=1, initial_evidence=20, update_interval=10, 
-                       bounds={'t1':(-2, 2), 't2':(-1, 1)}, acq_noise_var=[0.1, 0.1], seed=seed)
+                       bounds={'t1':(-2, 2), 't2':(-1, 1)}, acq_noise_var=0.1, seed=seed)
 
 Sometimes you may have some samples readily available. You could then
 initialize the GP model with a dictionary of previous results by giving

--- a/elfi/__init__.py
+++ b/elfi/__init__.py
@@ -31,4 +31,4 @@ __author__ = 'ELFI authors'
 __email__ = 'elfi-support@hiit.fi'
 
 # make sure __version_ is on the last non-empty line (read by setup.py)
-__version__ = '0.8.3'
+__version__ = '0.8.4'

--- a/elfi/examples/arch.py
+++ b/elfi/examples/arch.py
@@ -76,7 +76,6 @@ def arch(t1, t2, n_obs=100, batch_size=1, random_state=None):
 
     References
     ----------
-
     Engle, R.F. (1982). Autoregressive Conditional Heteroscedasticity with
         Estimates of the Variance of United Kingdom Inflation. Econometrica, 50(4): 987-1007
 
@@ -102,6 +101,7 @@ def arch(t1, t2, n_obs=100, batch_size=1, random_state=None):
     e = E(t2, n_obs, batch_size, random_state)
     for i in range(1, n_obs + 1):
         y[:, i] = t1 * y[:, i - 1] + e[:, i]
+
     return y[:, 1:]
 
 

--- a/elfi/examples/arch.py
+++ b/elfi/examples/arch.py
@@ -63,7 +63,22 @@ def get_model(n_obs=100, true_params=None, seed_obs=None, n_lags=5):
 
 
 def arch(t1, t2, n_obs=100, batch_size=1, random_state=None):
-    """Generate a sequence of samples from the ARCH(1) model.
+    r"""Generate a sequence of samples from the ARCH(1) regression model.
+
+    Autoregressive conditional heteroskedasticity (ARCH) sequence describes the variance
+    of the error term as a function of previous error terms.
+
+        x_i = t_1 x_{i-1} + \epsilon_i
+
+        \epsilon_i = w_i \sqrt{0.2 + t_2 \epsilon_{i-1}^2}
+
+    where w_i is white noise ~ N(0,1) independent of \epsilon_0 ~  N(0,1)
+
+    References
+    ----------
+
+    Engle, R.F. (1982). Autoregressive Conditional Heteroscedasticity with
+        Estimates of the Variance of United Kingdom Inflation. Econometrica, 50(4): 987-1007
 
     Parameters
     ----------

--- a/elfi/examples/lotka_volterra.py
+++ b/elfi/examples/lotka_volterra.py
@@ -74,8 +74,10 @@ def lotka_volterra(r1, r2, r3, prey_init=50, predator_init=100, sigma=0., n_obs=
 
     n_full = 20000
     stock = np.empty((batch_size, n_full, 2), dtype=np.int32)
-    stock[:, 0, 0] = prey_init
-    stock[:, 0, 1] = predator_init
+    # As we use approximate continuous priors for prey_init and
+    # predator_init, we'll round them down to closest integers
+    stock[:, 0, 0] = np.floor(prey_init)
+    stock[:, 0, 1] = np.floor(predator_init)
     stoichiometry = np.array([[1, 0], [-1, 1], [0, -1], [0, 0]], dtype=np.int32)
     times = np.empty((batch_size, n_full))
     times[:, 0] = 0
@@ -192,8 +194,8 @@ def get_model(n_obs=50, true_params=None, observation_noise=False, seed_obs=None
         elfi.Prior(ExpUniform, -6., 2., model=m, name='r1'),
         elfi.Prior(ExpUniform, -6., 2., model=m, name='r2'),  # easily kills populations
         elfi.Prior(ExpUniform, -6., 2., model=m, name='r3'),
-        elfi.Prior('poisson', 50, model=m, name='prey0'),
-        elfi.Prior('poisson', 100, model=m, name='predator0')
+        elfi.Prior('normal', 50, np.sqrt(50), model=m, name='prey0'),
+        elfi.Prior('normal', 100, np.sqrt(100), model=m, name='predator0')
     ]
 
     if observation_noise:

--- a/elfi/examples/lotka_volterra.py
+++ b/elfi/examples/lotka_volterra.py
@@ -222,6 +222,7 @@ def get_model(n_obs=50, true_params=None, observation_noise=False, seed_obs=None
 
 
 def stock_mean(stock, species=0, mu=0, std=1):
+    """Calculate the mean of the trajectory by species."""
     stock = np.atleast_2d(stock[:, :, species])
     mu_x = np.mean(stock, axis=1)
 
@@ -229,6 +230,7 @@ def stock_mean(stock, species=0, mu=0, std=1):
 
 
 def stock_log_variance(stock, species=0, mu=0, std=1):
+    """Calculate the log variance of the trajectory by species."""
     stock = np.atleast_2d(stock[:, :, species])
     var_x = np.var(stock, axis=1, ddof=1)
     log_x = np.log(var_x + 1)
@@ -237,13 +239,13 @@ def stock_log_variance(stock, species=0, mu=0, std=1):
 
 
 def stock_autocorr(stock, species=0, lag=1, mu=0, std=1):
+    """Calculate the autocorrelation of lag n of the trajectory by species."""
     stock = np.atleast_2d(stock[:, :, species])
     n_obs = stock.shape[1]
 
     mu_x = np.mean(stock, axis=1, keepdims=True)
     std_x = np.std(stock, axis=1, ddof=1, keepdims=True)
     sx = ((stock - np.repeat(mu_x, n_obs, axis=1)) / np.repeat(std_x, n_obs, axis=1))
-
     sx_t = sx[:, lag:]
     sx_s = sx[:, :-lag]
 
@@ -253,6 +255,7 @@ def stock_autocorr(stock, species=0, lag=1, mu=0, std=1):
 
 
 def stock_crosscorr(stock, mu=0, std=1):
+    """Calculate the cross correlation of the species trajectories."""
     n_obs = stock.shape[1]
 
     x_preys = stock[:, :, 0]  # preys

--- a/elfi/executor.py
+++ b/elfi/executor.py
@@ -107,6 +107,9 @@ class Executor:
         # Filter those output nodes who have an operation to run
         needed = tuple(sorted(node for node in output_nodes if 'operation' in G.nodes[node]))
 
+        if len(needed) == 0:
+            return []
+
         if needed not in cache:
             # Resolve the nodes that need to be executed in the graph
             nodes_to_execute = set(needed)

--- a/elfi/methods/bo/acquisition.py
+++ b/elfi/methods/bo/acquisition.py
@@ -7,7 +7,7 @@ import scipy.linalg as sl
 import scipy.stats as ss
 
 import elfi.methods.mcmc as mcmc
-from elfi.methods.bo.utils import minimize
+from elfi.methods.bo.utils import CostFunction, minimize
 from elfi.methods.utils import resolve_sigmas
 
 logger = logging.getLogger(__name__)
@@ -223,7 +223,7 @@ class LCBSC(AcquisitionBase):
 
     """
 
-    def __init__(self, *args, delta=None, include_prior=False, **kwargs):
+    def __init__(self, *args, delta=None, additive_cost=None, **kwargs):
         """Initialize LCBSC.
 
         Parameters
@@ -231,8 +231,8 @@ class LCBSC(AcquisitionBase):
         delta: float, optional
             In between (0, 1). Default is 1/exploration_rate. If given, overrides the
             exploration_rate.
-        include_prior: bool, optional
-            If true, add negative log prior to model evaluations.
+        additive_cost: CostFunction, optional
+            Cost function output is added to the base acquisition value.
 
         """
         if delta is not None:
@@ -243,7 +243,10 @@ class LCBSC(AcquisitionBase):
         super(LCBSC, self).__init__(*args, **kwargs)
         self.name = 'lcbsc'
         self.label_fn = 'Confidence Bound'
-        self.include_prior = include_prior
+
+        if additive_cost is not None and not isinstance(additive_cost, CostFunction):
+            raise TypeError("Additive cost must be type CostFunction.")
+        self.additive_cost = additive_cost
 
     @property
     def delta(self):
@@ -272,10 +275,8 @@ class LCBSC(AcquisitionBase):
         """
         mean, var = self.model.predict(x, noiseless=True)
         value = mean - np.sqrt(self._beta(t) * var)
-        if self.include_prior:
-            # we use negative prior, since we minimize
-            negative_log_prior = -1 * self.prior.logpdf(x).reshape(-1, 1)
-            value += negative_log_prior
+        if self.additive_cost is not None:
+            value += self.additive_cost.evaluate(x)
         return value
 
     def evaluate_gradient(self, x, t=None):
@@ -295,10 +296,8 @@ class LCBSC(AcquisitionBase):
         mean, var = self.model.predict(x, noiseless=True)
         grad_mean, grad_var = self.model.predictive_gradients(x)
         value = grad_mean - 0.5 * grad_var * np.sqrt(self._beta(t) / var)
-        if self.include_prior:
-            # we use negative prior, since we minimize
-            grad_negative_log_prior = -1 * self.prior.gradient_logpdf(x).reshape(1, -1)
-            value += grad_negative_log_prior
+        if self.additive_cost is not None:
+            value += self.additive_cost.evaluate_gradient(x)
         return value
 
 

--- a/elfi/methods/bo/acquisition.py
+++ b/elfi/methods/bo/acquisition.py
@@ -62,14 +62,44 @@ class AcquisitionBase:
         self.n_inits = int(n_inits)
         self.max_opt_iters = int(max_opt_iters)
         self.constraints = constraints
-
-        if noise_var is not None and np.asanyarray(noise_var).ndim > 1:
-            raise ValueError("Noise variance must be a float or 1d vector of variances "
-                             "for the different input dimensions.")
-        self.noise_var = noise_var
+        if noise_var is not None:
+            self._check_noise_var(noise_var)
+            self.noise_var = self._transform_noise_var(noise_var)
+        else:
+            self.noise_var = noise_var
         self.exploration_rate = exploration_rate
         self.random_state = np.random if seed is None else np.random.RandomState(seed)
         self.seed = 0 if seed is None else seed
+
+    def _check_noise_var(self, noise_var):
+        if isinstance(noise_var, dict):
+            if not set(noise_var) == set(self.model.parameter_names):
+                raise ValueError("Acquisition noise dictionary should contain all parameters.")
+
+            if not all(isinstance(x, (int, float)) for x in noise_var.values()):
+                raise ValueError("Acquisition noise dictionary values "
+                                 "should all be int or float.")
+
+            if any([x < 0 for x in noise_var.values()]):
+                raise ValueError("Acquisition noises values should all be "
+                                 "non-negative int or float.")
+
+        elif isinstance(noise_var, (int, float)):
+            if noise_var < 0:
+                raise ValueError("Acquisition noise should be non-negative int or float.")
+        else:
+            raise ValueError("Either acquisition noise is a float or "
+                             "it is a dictionary of floats defining "
+                             "variance for each parameter dimension.")
+
+    def _transform_noise_var(self, noise_var):
+        if isinstance(noise_var, (float, int)):
+            return noise_var
+
+        # return a sorted list of noise variances in the same order than
+        # parameter_names of the model
+        if isinstance(noise_var, dict):
+            return list(map(noise_var.get, self.model.parameter_names))
 
     def evaluate(self, x, t=None):
         """Evaluate the acquisition function at 'x'.

--- a/elfi/methods/bo/gpy_regression.py
+++ b/elfi/methods/bo/gpy_regression.py
@@ -73,6 +73,7 @@ class GPyRegression:
             raise ValueError("Keyword `bounds` must be a dictionary "
                              "`{'parameter_name': (lower, upper), ... }`")
 
+        self.parameter_names = parameter_names
         self.input_dim = input_dim
         self.bounds = bounds
 

--- a/elfi/methods/bo/utils.py
+++ b/elfi/methods/bo/utils.py
@@ -108,3 +108,56 @@ def minimize(fun,
         locs_out[i] = np.clip(locs_out[i], *bounds[i])
 
     return locs[ind_min], vals[ind_min]
+
+
+class CostFunction:
+    """Convenience class for modelling acquisition costs."""
+
+    def __init__(self, function, gradient, scale=1):
+        """Initialise CostFunction.
+
+        Parameters
+        ----------
+        function : callable
+            Function that returns cost function value.
+        gradient : callable
+            Function that returns cost function gradient.
+        scale : float, optional
+            Cost function is multiplied with scale.
+
+        """
+        self.function = function
+        self.gradient = gradient
+        self.scale = scale
+
+    def evaluate(self, x):
+        """Return cost function value evaluated at x.
+
+        Parameters
+        ----------
+        x : np.ndarray, shape: (input_dim,) or (n, input_dim)
+
+        Returns
+        -------
+        np.ndarray, shape: (n, 1)
+
+        """
+        x = np.atleast_2d(x)
+        n, input_dim = x.shape
+        return self.scale * self.function(x).reshape(n, 1)
+
+    def evaluate_gradient(self, x):
+        """Return cost function gradient evaluated at x.
+
+        Parameters
+        ----------
+        x : np.ndarray, shape: (input_dim,) or (n, input_dim)
+
+        Returns
+        -------
+        np.ndarray, shape: (n, input_dim)
+
+        """
+        x = np.atleast_2d(x)
+        n, input_dim = x.shape
+        return self.scale * self.gradient(x).reshape(n, input_dim)

--- a/elfi/methods/inference/bolfi.py
+++ b/elfi/methods/inference/bolfi.py
@@ -99,9 +99,9 @@ class BayesianOptimization(ParameterInference):
 
         self.batches_per_acquisition = batches_per_acquisition or self.max_parallel_batches
 
+        prior = ModelPrior(self.model, parameter_names=self.target_model.parameter_names)
         self.acquisition_method = acquisition_method or LCBSC(self.target_model,
-                                                              prior=ModelPrior(
-                                                                  self.model),
+                                                              prior=prior,
                                                               noise_var=acq_noise_var,
                                                               exploration_rate=exploration_rate,
                                                               seed=self.seed)
@@ -456,7 +456,8 @@ class BOLFI(BayesianOptimization):
             raise ValueError(
                 'Model is not fitted yet, please see the `fit` method.')
 
-        return BolfiPosterior(self.target_model, threshold=threshold, prior=ModelPrior(self.model))
+        prior = ModelPrior(self.model, parameter_names=self.target_model.parameter_names)
+        return BolfiPosterior(self.target_model, threshold=threshold, prior=prior)
 
     def sample(self,
                n_samples,

--- a/elfi/methods/inference/bolfi.py
+++ b/elfi/methods/inference/bolfi.py
@@ -59,9 +59,9 @@ class BayesianOptimization(ParameterInference):
         target_model : GPyRegression, optional
         acquisition_method : Acquisition, optional
             Method of acquiring evidence points. Defaults to LCBSC.
-        acq_noise_var : float or np.array, optional
+        acq_noise_var : float or dict, optional
             Variance(s) of the noise added in the default LCBSC acquisition method.
-            If an array, should be 1d specifying the variance for each dimension.
+            If a dictionary, values should be float specifying the variance for each dimension.
         exploration_rate : float, optional
             Exploration rate of the acquisition method
         batch_size : int, optional
@@ -98,6 +98,7 @@ class BayesianOptimization(ParameterInference):
             self.target_model.update(params, precomputed[target_name])
 
         self.batches_per_acquisition = batches_per_acquisition or self.max_parallel_batches
+
         self.acquisition_method = acquisition_method or LCBSC(self.target_model,
                                                               prior=ModelPrior(
                                                                   self.model),

--- a/elfi/methods/inference/bolfi.py
+++ b/elfi/methods/inference/bolfi.py
@@ -326,7 +326,7 @@ class BayesianOptimization(ParameterInference):
             if len(gp.X) > 1:
                 f.axes[1].scatter(*point, color='red')
 
-        displays = [gp._gp]
+        displays = [gp.instance]
 
         if options.get('interactive'):
             from IPython import display
@@ -338,8 +338,9 @@ class BayesianOptimization(ParameterInference):
         # Update
         visin._update_interactive(displays, options)
 
+        acq_index = self._get_acquisition_index(self.state['n_batches'])
         def acq(x):
-            return self.acquisition_method.evaluate(x, len(gp.X))
+            return self.acquisition_method.evaluate(x, acq_index)
 
         # Draw the acquisition surface
         visin.draw_contour(

--- a/elfi/methods/inference/bolfi.py
+++ b/elfi/methods/inference/bolfi.py
@@ -17,7 +17,7 @@ from elfi.methods.bo.utils import stochastic_optimization
 from elfi.methods.inference.parameter_inference import ParameterInference
 from elfi.methods.posteriors import BolfiPosterior
 from elfi.methods.results import BolfiSample, OptimizationResult
-from elfi.methods.utils import arr2d_to_batch, batch_to_arr2d, ceil_to_batch_size
+from elfi.methods.utils import arr2d_to_batch, batch_to_arr2d, ceil_to_batch_size, resolve_sigmas
 from elfi.model.extensions import ModelPrior
 
 logger = logging.getLogger(__name__)
@@ -490,9 +490,9 @@ class BOLFI(BayesianOptimization):
             Defaults to best evidence points.
         algorithm : string, optional
             Sampling algorithm to use. Currently 'nuts'(default) and 'metropolis' are supported.
-        sigma_proposals : np.array
+        sigma_proposals : dict, optional
             Standard deviations for Gaussian proposals of each parameter for Metropolis
-            Markov Chain sampler.
+            Markov Chain sampler. Defaults to 1/10 of surrogate model bound lengths.
         n_evidence : int
             If the regression model is not fitted yet, specify the amount of evidence
 
@@ -525,12 +525,9 @@ class BOLFI(BayesianOptimization):
         tasks_ids = []
         ii_initial = 0
         if algorithm == 'metropolis':
-            if sigma_proposals is None:
-                raise ValueError("Gaussian proposal standard deviations "
-                                 "have to be provided for Metropolis-sampling.")
-            elif sigma_proposals.shape[0] != self.target_model.input_dim:
-                raise ValueError("The length of Gaussian proposal standard "
-                                 "deviations must be n_params.")
+            sigma_proposals = resolve_sigmas(self.target_model.parameter_names,
+                                             sigma_proposals,
+                                             self.target_model.bounds)
 
         # sampling is embarrassingly parallel, so depending on self.client this may parallelize
         for ii in range(n_chains):

--- a/elfi/methods/inference/bolfi.py
+++ b/elfi/methods/inference/bolfi.py
@@ -339,6 +339,7 @@ class BayesianOptimization(ParameterInference):
         visin._update_interactive(displays, options)
 
         acq_index = self._get_acquisition_index(self.state['n_batches'])
+
         def acq(x):
             return self.acquisition_method.evaluate(x, acq_index)
 

--- a/elfi/methods/inference/bolfire.py
+++ b/elfi/methods/inference/bolfire.py
@@ -14,7 +14,7 @@ from elfi.methods.bo.gpy_regression import GPyRegression
 from elfi.methods.inference.parameter_inference import ParameterInference
 from elfi.methods.posteriors import BOLFIREPosterior
 from elfi.methods.results import BOLFIRESample
-from elfi.methods.utils import arr2d_to_batch, batch_to_arr2d
+from elfi.methods.utils import arr2d_to_batch, batch_to_arr2d, resolve_sigmas
 from elfi.model.elfi_model import ElfiModel, Summary
 from elfi.model.extensions import ModelPrior
 
@@ -269,12 +269,9 @@ class BOLFIRE(ParameterInference):
 
         # Check standard deviations of Gaussian proposals when using Metropolis-Hastings
         if algorithm == 'metropolis':
-            if sigma_proposals is None:
-                raise ValueError('Gaussian proposal standard deviations have '
-                                 'to be provided for Metropolis-sampling.')
-            elif sigma_proposals.shape[0] != self.target_model.input_dim:
-                raise ValueError('The length of Gaussian proposal standard '
-                                 'deviations must be n_params.')
+            sigma_proposals = resolve_sigmas(self.target_model.parameter_names,
+                                             sigma_proposals,
+                                             self.target_model.bounds)
 
         posterior = self.extract_result()
         warmup = warmup or n_samples // 2

--- a/elfi/methods/inference/bolfire.py
+++ b/elfi/methods/inference/bolfire.py
@@ -58,9 +58,9 @@ class BOLFIRE(ParameterInference):
             custom target_model is given.
         n_initial_evidence: int, optional
             Number of initial evidence.
-        acq_noise_var: float or np.ndarray, optional
+        acq_noise_var : float or dict, optional
             Variance(s) of the noise added in the default LCBSC acquisition method.
-            If an array, should be 1d specifying the variance for each dimension.
+            If a dictionary, values should be float specifying the variance for each dimension.
         exploration_rate: float, optional
             Exploration rate of the acquisition method.
         update_interval : int, optional

--- a/elfi/methods/inference/bolfire.py
+++ b/elfi/methods/inference/bolfire.py
@@ -11,6 +11,7 @@ from elfi.classifiers.classifier import Classifier, LogisticRegression
 from elfi.loader import get_sub_seed
 from elfi.methods.bo.acquisition import LCBSC, AcquisitionBase
 from elfi.methods.bo.gpy_regression import GPyRegression
+from elfi.methods.bo.utils import CostFunction
 from elfi.methods.inference.parameter_inference import ParameterInference
 from elfi.methods.posteriors import BOLFIREPosterior
 from elfi.methods.results import BOLFIRESample
@@ -91,6 +92,9 @@ class BOLFIRE(ParameterInference):
 
         # Initialize GP regression
         self.target_model = self._resolve_target_model(target_model)
+
+        # Define acquisition cost
+        self.cost = CostFunction(self.prior.logpdf, self.prior.gradient_logpdf, scale=-1)
 
         # Initialize BO
         self.n_initial_evidence = self._resolve_n_initial_evidence(n_initial_evidence)
@@ -434,7 +438,7 @@ class BOLFIRE(ParameterInference):
                          noise_var=self.acq_noise_var,
                          exploration_rate=self.exploration_rate,
                          seed=self.seed,
-                         include_prior=True)
+                         additive_cost=self.cost)
         if isinstance(acquisition_method, AcquisitionBase):
             return acquisition_method
         raise TypeError('acquisition_method must be an instance of AcquisitionBase.')

--- a/elfi/methods/inference/bolfire.py
+++ b/elfi/methods/inference/bolfire.py
@@ -412,7 +412,7 @@ class BOLFIRE(ParameterInference):
 
     def _get_parameter_values(self, batch):
         """Return parameter values from a given batch."""
-        return {parameter_name: float(batch[parameter_name]) for parameter_name
+        return {parameter_name: batch[parameter_name] for parameter_name
                 in self.model.parameter_names}
 
     def _resolve_n_initial_evidence(self, n_initial_evidence):

--- a/elfi/methods/inference/bolfire.py
+++ b/elfi/methods/inference/bolfire.py
@@ -107,6 +107,11 @@ class BOLFIRE(ParameterInference):
         # Initialize classifier attributes list
         self.classifier_attributes = []
 
+        # Initialize data collection
+        self._likelihood = np.zeros((self.n_training_data, self.marginal.shape[1]))
+        self._random_state = np.random.RandomState(self.seed)
+        self._init_round()
+
     @property
     def n_evidence(self):
         """Return the number of acquired evidence points."""
@@ -123,7 +128,7 @@ class BOLFIRE(ParameterInference):
         """
         if n_evidence < self.n_evidence:
             logger.warning('Requesting less evidence than there already exists.')
-        self.objective['n_sim'] = n_evidence
+        self.objective['n_batches'] = n_evidence * int(self.n_training_data / self.batch_size)
 
     def extract_result(self):
         """Extract the results from the current state."""
@@ -144,25 +149,12 @@ class BOLFIRE(ParameterInference):
             Index of batch.
 
         """
-        # Update the inference state
-        self.state['n_batches'] += 1
-        self.state['n_sim'] += self.batch_size * self.n_training_data
+        super(BOLFIRE, self).update(batch, batch_index)
 
-        # Predict log-ratio
-        likelihood = self._generate_likelihood(self._get_parameter_values(batch))
-        X, y = self._generate_training_data(likelihood, self.marginal)
-        negative_log_ratio_value = -1 * self.predict_log_ratio(X, y, self.observed)
-
-        # Update classifier attributes list
-        self.classifier_attributes += [self.classifier.attributes]
-
-        # BO part
-        self.state['n_evidence'] += self.batch_size
-        parameter_values = batch_to_arr2d(batch, self.target_model.parameter_names)
-        optimize = self._should_optimize()
-        self.target_model.update(parameter_values, negative_log_ratio_value, optimize)
-        if optimize:
-            self.state['last_GP_update'] = self.target_model.n_evidence
+        self._merge_batch(batch)
+        if self._round_sim == self.n_training_data:
+            self._update_logratio_model()
+            self._init_round()
 
     def prepare_new_batch(self, batch_index):
         """Prepare values for a new batch.
@@ -176,13 +168,8 @@ class BOLFIRE(ParameterInference):
         batch: dict
 
         """
-        t = batch_index - self.n_initial_evidence
-        if t < 0:  # Sample parameter values from the model priors
-            return
-
-        # Acquire parameter values from the acquisition function
-        acquisition = self.acquisition_method.acquire(self.batch_size, t)
-        return arr2d_to_batch(acquisition, self.target_model.parameter_names)
+        batch_parameters = np.repeat(self._params, self.batch_size, axis=0)
+        return arr2d_to_batch(batch_parameters, self.target_model.parameter_names)
 
     def predict_log_ratio(self, X, y, X_obs):
         """Predict the log-ratio, i.e, logarithm of likelihood / marginal.
@@ -360,7 +347,9 @@ class BOLFIRE(ParameterInference):
     def _resolve_n_training_data(self, n_training_data):
         """Resolve the size of training data to be used."""
         if isinstance(n_training_data, int) and n_training_data > 0:
-            return n_training_data
+            if n_training_data % self.batch_size == 0:
+                return n_training_data
+            raise ValueError('n_training_data must be a multiple of batch_size.')
         raise TypeError('n_training_data must be a positive int.')
 
     def _get_summary_names(self, model):
@@ -384,20 +373,7 @@ class BOLFIRE(ParameterInference):
         batch = self.model.generate(self.n_training_data,
                                     outputs=self.summary_names,
                                     seed=seed_marginal)
-        return np.column_stack([batch[summary_name] for summary_name in self.summary_names])
-
-    def _generate_likelihood(self, parameter_values):
-        """Generate likelihood data."""
-        batch = self.model.generate(self.n_training_data,
-                                    outputs=self.summary_names,
-                                    with_values=parameter_values)
-        return np.column_stack([batch[summary_name] for summary_name in self.summary_names])
-
-    def _generate_training_data(self, likelihood, marginal):
-        """Generate training data."""
-        X = np.vstack((likelihood, marginal))
-        y = np.concatenate((np.ones(likelihood.shape[0]), -1 * np.ones(marginal.shape[0])))
-        return X, y
+        return batch_to_arr2d(batch, self.summary_names)
 
     def _resolve_classifier(self, classifier):
         """Resolve classifier."""
@@ -410,11 +386,6 @@ class BOLFIRE(ParameterInference):
     def _get_observed_summary_values(self, model, summary_names):
         """Return observed values for summary statistics."""
         return np.column_stack([model[summary_name].observed for summary_name in summary_names])
-
-    def _get_parameter_values(self, batch):
-        """Return parameter values from a given batch."""
-        return {parameter_name: batch[parameter_name] for parameter_name
-                in self.target_model.parameter_names}
 
     def _resolve_n_initial_evidence(self, n_initial_evidence):
         """Resolve number of initial evidence."""
@@ -443,8 +414,62 @@ class BOLFIRE(ParameterInference):
             return acquisition_method
         raise TypeError('acquisition_method must be an instance of AcquisitionBase.')
 
+    def _init_round(self):
+        """Initialize data collection round."""
+        self._round_sim = 0
+
+        # Set new parameter values
+        if self.n_evidence < self.n_initial_evidence:
+            # Sample parameter values from the model priors
+            self._params = self.prior.rvs(1, random_state=self._random_state)
+        else:
+            # Acquire parameter values from the acquisition function
+            t = self.n_evidence - self.n_initial_evidence
+            self._params = self.acquisition_method.acquire(1, t)
+
+    def _new_round(self, batch_index):
+        """Check whether batch_index starts a new data collection round."""
+        return (batch_index * self.batch_size) % self.n_training_data == 0
+
+    def _allow_submit(self, batch_index):
+        """Check whether batch_index can be prepared."""
+        # Do not prepare batches with new parameter values until the current round is finished
+        if self._new_round(batch_index) and self.batches.has_pending:
+            return False
+        else:
+            return super(BOLFIRE, self)._allow_submit(batch_index)
+
+    def _merge_batch(self, batch):
+        """Add batch to collected data."""
+        data = batch_to_arr2d(batch, self.summary_names)
+        self._likelihood[self._round_sim:self._round_sim + self.batch_size] = data
+        self._round_sim += self.batch_size
+
+    def _update_logratio_model(self):
+        """Calculate log-ratio based on collected data and update surrogate model."""
+        # Predict log-ratio
+        X, y = self._generate_training_data(self._likelihood, self.marginal)
+        negative_log_ratio_value = -1 * self.predict_log_ratio(X, y, self.observed)
+
+        # Update classifier attributes list
+        self.classifier_attributes += [self.classifier.attributes]
+
+        # BO part
+        self.state['n_evidence'] += 1
+        parameter_values = self._params
+        optimize = self._should_optimize()
+        self.target_model.update(parameter_values, negative_log_ratio_value, optimize)
+        if optimize:
+            self.state['last_GP_update'] = self.target_model.n_evidence
+
+    def _generate_training_data(self, likelihood, marginal):
+        """Generate training data."""
+        X = np.vstack((likelihood, marginal))
+        y = np.concatenate((np.ones(likelihood.shape[0]), -1 * np.ones(marginal.shape[0])))
+        return X, y
+
     def _should_optimize(self):
         """Check whether GP hyperparameters should be optimized."""
-        current = self.target_model.n_evidence + self.batch_size
+        current = self.target_model.n_evidence + 1
         next_update = self.state['last_GP_update'] + self.update_interval
         return current >= self.n_initial_evidence and current >= next_update

--- a/elfi/methods/inference/bolfire.py
+++ b/elfi/methods/inference/bolfire.py
@@ -85,7 +85,6 @@ class BOLFIRE(ParameterInference):
         self.marginal = self._resolve_marginal(marginal, seed_marginal)
         self.classifier = self._resolve_classifier(classifier)
         self.observed = self._get_observed_feature_values(self.model, self.feature_names)
-        self.prior = ModelPrior(self.model)
 
         # TODO: write resolvers for the attributes below
         self.bounds = bounds
@@ -95,6 +94,7 @@ class BOLFIRE(ParameterInference):
 
         # Initialize GP regression
         self.target_model = self._resolve_target_model(target_model)
+        self.prior = ModelPrior(self.model, parameter_names=self.target_model.parameter_names)
 
         # Define acquisition cost
         self.cost = CostFunction(self.prior.logpdf, self.prior.gradient_logpdf, scale=-1)

--- a/elfi/methods/inference/bolfire.py
+++ b/elfi/methods/inference/bolfire.py
@@ -127,7 +127,7 @@ class BOLFIRE(ParameterInference):
 
     def extract_result(self):
         """Extract the results from the current state."""
-        return BOLFIREPosterior(self.parameter_names,
+        return BOLFIREPosterior(self.target_model.parameter_names,
                                 self.target_model,
                                 self.prior,
                                 self.classifier_attributes)
@@ -158,7 +158,7 @@ class BOLFIRE(ParameterInference):
 
         # BO part
         self.state['n_evidence'] += self.batch_size
-        parameter_values = batch_to_arr2d(batch, self.parameter_names)
+        parameter_values = batch_to_arr2d(batch, self.target_model.parameter_names)
         optimize = self._should_optimize()
         self.target_model.update(parameter_values, negative_log_ratio_value, optimize)
         if optimize:
@@ -182,7 +182,7 @@ class BOLFIRE(ParameterInference):
 
         # Acquire parameter values from the acquisition function
         acquisition = self.acquisition_method.acquire(self.batch_size, t)
-        return arr2d_to_batch(acquisition, self.parameter_names)
+        return arr2d_to_batch(acquisition, self.target_model.parameter_names)
 
     def predict_log_ratio(self, X, y, X_obs):
         """Predict the log-ratio, i.e, logarithm of likelihood / marginal.
@@ -335,7 +335,7 @@ class BOLFIRE(ParameterInference):
 
         logger.info(f'{n_chains} chains of {n_samples} iterations acquired. '
                     'Effective sample size and Rhat for each parameter:')
-        for ii, node in enumerate(self.parameter_names):
+        for ii, node in enumerate(self.target_model.parameter_names):
             logger.info(f'{node} {mcmc.eff_sample_size(chains[:, :, ii])} '
                         f'{mcmc.gelman_rubin_statistic(chains[:, :, ii])}')
 
@@ -343,7 +343,7 @@ class BOLFIRE(ParameterInference):
 
         return BOLFIRESample(method_name='BOLFIRE',
                              chains=chains,
-                             parameter_names=self.parameter_names,
+                             parameter_names=self.target_model.parameter_names,
                              warmup=warmup,
                              n_sim=self.state['n_sim'],
                              seed=self.seed,
@@ -414,7 +414,7 @@ class BOLFIRE(ParameterInference):
     def _get_parameter_values(self, batch):
         """Return parameter values from a given batch."""
         return {parameter_name: batch[parameter_name] for parameter_name
-                in self.model.parameter_names}
+                in self.target_model.parameter_names}
 
     def _resolve_n_initial_evidence(self, n_initial_evidence):
         """Resolve number of initial evidence."""

--- a/elfi/methods/inference/romc.py
+++ b/elfi/methods/inference/romc.py
@@ -86,9 +86,9 @@ class BoDetereministic:
         target_model : GPyRegression, optional
         acquisition_method : Acquisition, optional
             Method of acquiring evidence points. Defaults to LCBSC.
-        acq_noise_var : float or np.array, optional
+        acq_noise_var : float or dict, optional
             Variance(s) of the noise added in the default LCBSC acquisition method.
-            If an array, should be 1d specifying the variance for each dimension.
+            If a dictionary, values should be float specifying the variance for each dimension.
         exploration_rate : float, optional
             Exploration rate of the acquisition method
         batch_size : int, optional

--- a/elfi/methods/results.py
+++ b/elfi/methods/results.py
@@ -8,11 +8,12 @@ import string
 import sys
 from collections import OrderedDict
 
+import matplotlib.pyplot as plt
 import numpy as np
-from matplotlib import pyplot as plt
 
 import elfi.visualization.visualization as vis
-from elfi.methods.utils import numpy_to_python_type, sample_object_to_dict
+from elfi.methods.utils import (numpy_to_python_type, sample_object_to_dict,
+                                weighted_sample_quantile)
 
 logger = logging.getLogger(__name__)
 
@@ -174,7 +175,7 @@ class Sample(ParameterInferenceResult):
             desc += "Threshold: {:.3g}\n".format(self.threshold)
         print(desc, end='')
         try:
-            self.sample_means_summary()
+            self.sample_summary()
         except TypeError:
             pass
 
@@ -182,7 +183,28 @@ class Sample(ParameterInferenceResult):
         """Print a representation of sample means."""
         s = "Sample means: "
         s += ', '.join(["{}: {:.3g}".format(k, v) for k, v in self.sample_means.items()])
-        print(s)
+        print(s)        
+
+    def sample_summary(self):
+        """Print sample mean and 95% credible interval."""
+        print("{0:24} {1:18} {2:17} {3:5}".format("Parameter", "Mean", "2.5%", "97.5%"))
+        print(''.join([
+            "{0:10} "
+            "{1:18.3f} "
+            "{2:18.3f} "
+            "{3:18.3f}\n"
+            .format(k[:10] + ":", v[0], v[1], v[2])
+            for k, v in self.sample_means_and_95CIs.items()]))
+
+    @property
+    def sample_means_and_95CIs(self):
+        """Construct OrderedDict for mean and 95% credible interval."""
+        return OrderedDict(
+            [(k, (np.average(v, axis=0, weights=self.weights),
+                  weighted_sample_quantile(v, alpha=0.025, weights=self.weights),
+                  weighted_sample_quantile(v, alpha=0.975, weights=self.weights)))
+             for k, v in self.samples.items()]
+                            )
 
     @property
     def sample_means(self):
@@ -194,6 +216,11 @@ class Sample(ParameterInferenceResult):
 
         """
         return OrderedDict([(k, np.average(v, axis=0, weights=self.weights))
+                            for k, v in self.samples.items()])
+
+    def sample_quantiles(self, alpha=0.5):
+        """Evaluate weighted sample quantiles of sampled parameters."""
+        return OrderedDict([(k, weighted_sample_quantile(v, alpha=alpha, weights=self.weights))
                             for k, v in self.samples.items()])
 
     @property

--- a/elfi/methods/results.py
+++ b/elfi/methods/results.py
@@ -183,7 +183,7 @@ class Sample(ParameterInferenceResult):
         """Print a representation of sample means."""
         s = "Sample means: "
         s += ', '.join(["{}: {:.3g}".format(k, v) for k, v in self.sample_means.items()])
-        print(s)        
+        print(s)
 
     def sample_summary(self):
         """Print sample mean and 95% credible interval."""

--- a/elfi/methods/utils.py
+++ b/elfi/methods/utils.py
@@ -2,7 +2,7 @@
 
 import logging
 from math import ceil
-from typing import Union
+from typing import Dict, List, Optional, Union
 
 import numpy as np
 import scipy.stats as ss
@@ -455,3 +455,46 @@ def flat_array_to_dict(names, arr):
     for ii, param_name in enumerate(names):
         param_dict[param_name] = np.expand_dims(arr[ii:ii + 1], 0)
     return param_dict
+
+
+def resolve_sigmas(parameter_names: List[str],
+                   sigma_proposals: Optional[Dict] = None,
+                   bounds: Optional[Dict] = None) -> List:
+    """Map dictionary of sigma_proposals into a list order as parameter_names.
+
+    Parameters
+    ----------
+    parameter_names: List[str]
+        names of the parameters
+    sigma_proposals: Dict
+        non-negative standard deviations for each dimension
+        {'parameter_name': float}
+    bounds : Dict, optional
+        the region where to estimate the posterior for each parameter in
+        model.parameters
+        `{'parameter_name':(lower, upper), ... }
+
+    Returns
+    -------
+    List
+       list of sigma_proposals in the same order than in parameter_names
+
+    """
+    if sigma_proposals is None:
+        sigma_proposals = []
+        for bound in bounds:
+            length_interval = bound[1] - bound[0]
+            sigma_proposals.append(length_interval / 10)
+    elif isinstance(sigma_proposals, dict):
+        errmsg = "sigma_proposals' keys have to be identical to " \
+                    "target_model.parameter_names."
+        if len(sigma_proposals) is not len(parameter_names):
+            raise ValueError(errmsg)
+        try:
+            sigma_proposals = [sigma_proposals[x] for x in parameter_names]
+        except ValueError:
+            print(parameter_names)
+    else:
+        raise ValueError("If provided, sigma_proposals need to be input as a dict.")
+
+    return sigma_proposals

--- a/elfi/model/elfi_model.py
+++ b/elfi/model/elfi_model.py
@@ -277,7 +277,7 @@ class ElfiModel(GraphicalModel):
 
         """
         if outputs is None:
-            outputs = self.source_net.nodes()
+            outputs = list(self.source_net.nodes())
         elif isinstance(outputs, str):
             outputs = [outputs]
         if not isinstance(outputs, list):

--- a/elfi/model/extensions.py
+++ b/elfi/model/extensions.py
@@ -116,18 +116,30 @@ class ScipyLikeDistribution:
 # TODO: could use some optimization
 # TODO: support the case where some priors are multidimensional
 class ModelPrior:
-    """Construct a joint prior distribution over all the parameter nodes in `ElfiModel`."""
+    """Construct a joint prior distribution over all or selected parameter nodes in `ElfiModel`."""
 
-    def __init__(self, model):
+    def __init__(self, model, parameter_names=None):
         """Initialize a ModelPrior.
 
         Parameters
         ----------
         model : ElfiModel
+        parameter_names : list, optional
+            Parameters included in the prior and their order. Default model.parameter_names.
 
         """
         model = model.copy()
-        self.parameter_names = model.parameter_names
+
+        if parameter_names is None:
+            self.parameter_names = model.parameter_names
+        elif isinstance(parameter_names, list):
+            for param in parameter_names:
+                if param not in model.parameter_names:
+                    raise ValueError(f"Parameter \'{param}\' not found in model parameters.")
+            self.parameter_names = parameter_names
+        else:
+            raise ValueError("parameter_names must be a list of strings.")
+
         self.dim = len(self.parameter_names)
         self.client = Client()
 

--- a/elfi/utils.py
+++ b/elfi/utils.py
@@ -54,7 +54,7 @@ def args_to_tuple(*args):
 
 def is_array(output):
     """Check if `output` behaves as np.array (simple)."""
-    return hasattr(output, 'shape')
+    return hasattr(output, 'shape') and output.ndim > 0
 
 
 # NetworkX utils

--- a/tests/functional/test_bolfire.py
+++ b/tests/functional/test_bolfire.py
@@ -90,7 +90,7 @@ def test_bolfire(true_param, seed):
     assert bolfire_method.n_evidence == n_evidence
 
     # check the map estimates
-    map_estimates = bolfire_posterior.map_estimates
+    map_estimates = bolfire_posterior.compute_map_estimates()
     assert np.abs(map_estimates['mu'] - true_param) <= 0.5
 
     # run sampling

--- a/tests/functional/test_bolfire.py
+++ b/tests/functional/test_bolfire.py
@@ -45,17 +45,15 @@ def test_bolfire_init(true_param, seed):
     m = simple_gaussian_model(true_param, seed)
 
     # define the bolfire method
-    bolfire_method = elfi.BOLFIRE(model=m)
+    bolfire_method = elfi.BOLFIRE(model=m, n_training_data=10)
 
-    # check the default size of training data
-    assert bolfire_method.n_training_data == 10
     # check the size of mariginal data (should be the size of training data x number of summaries)
     assert bolfire_method.marginal.shape == (10, 10)
-    # check the summary names
-    assert bolfire_method.summary_names == [f'power_{i}' for i in range(10)]
+    # check the feature names
+    assert bolfire_method.feature_names == [f'power_{i}' for i in range(10)]
     # check the type of a default classifier
     assert isinstance(bolfire_method.classifier, LogisticRegression)
-    # check the lenght of observed summary values
+    # check the length of observed feature values
     assert len(bolfire_method.observed[0]) == 10
     # check the type of the prior
     assert isinstance(bolfire_method.prior, ModelPrior)

--- a/tests/unit/test_bo.py
+++ b/tests/unit/test_bo.py
@@ -99,7 +99,7 @@ def test_acquisition():
     assert np.all((new[:, 1] >= bounds['b'][0]) & (new[:, 1] <= bounds['b'][1]))
 
     # check acquisition with separate variance for dimensions
-    acq_noise_var = np.random.uniform(0, 5, size=2)
+    acq_noise_var = {'a': 0.1, 'b': 0.5}
     t = 1
     acquisition_method = acquisition.LCBSC(target_model, noise_var=acq_noise_var)
     new = acquisition_method.acquire(n2, t=t)
@@ -111,12 +111,21 @@ def test_acquisition():
     acq_noise_cov = np.random.rand(n_params, n_params) * 0.5
     acq_noise_cov += acq_noise_cov.T
     acq_noise_cov += n_params * np.eye(n_params)
-    t = 1
     with pytest.raises(ValueError):
         acquisition.LCBSC(target_model, noise_var=acq_noise_cov)
 
+    # check acquisition with negative variances
+    acq_noise_var = -0.1
+    with pytest.raises(ValueError):
+        acquisition.LCBSC(target_model, noise_var=acq_noise_var)
+
+    acq_noise_var = {'a': 0.1, 'b': -0.1}
+    with pytest.raises(ValueError):
+        acquisition.LCBSC(target_model, noise_var=acq_noise_var)
+
     # test Uniform Acquisition
     t = 1
+    acq_noise_var = 0.1
     acquisition_method = acquisition.UniformAcquisition(target_model, noise_var=acq_noise_var)
     new = acquisition_method.acquire(n2, t=t)
     assert new.shape == (n2, n_params)

--- a/tests/unit/test_bolfire_unit.py
+++ b/tests/unit/test_bolfire_unit.py
@@ -52,12 +52,8 @@ def test_generate_marginal(bolfire_method):
     assert bolfire_method._generate_marginal().shape == (10, 10)
 
 
-def test_generate_likelihood(bolfire_method, parameter_values):
-    assert bolfire_method._generate_likelihood(parameter_values).shape == (10, 10)
-
-
 def test_generate_training_data(bolfire_method, parameter_values):
-    likelihood = bolfire_method._generate_likelihood(parameter_values)
+    likelihood = np.random.rand(10, 10)
     X, y = bolfire_method._generate_training_data(likelihood, bolfire_method.marginal)
     assert X.shape == (20, 10)
     assert y.shape == (20,)

--- a/tests/unit/test_bolfire_unit.py
+++ b/tests/unit/test_bolfire_unit.py
@@ -45,7 +45,7 @@ def parameter_values():
 @pytest.fixture
 def bolfire_method(true_param, seed):
     m = simple_gaussian_model(true_param, seed)
-    return elfi.BOLFIRE(m)
+    return elfi.BOLFIRE(m, 10)
 
 
 def test_generate_marginal(bolfire_method):

--- a/tests/unit/test_elfi_model.py
+++ b/tests/unit/test_elfi_model.py
@@ -20,6 +20,17 @@ def test_generate(ma2):
 
 
 @pytest.mark.usefixtures('with_all_clients')
+def test_generate_outputs(ma2):
+    n_gen = 10
+
+    res = ma2.generate(n_gen)
+
+    assert 'd' in res
+    assert res['d'].shape[0] == n_gen
+    assert res['d'].ndim == 1
+
+
+@pytest.mark.usefixtures('with_all_clients')
 def test_observed():
     true_params = [.6, .2]
     m = ema2.get_model(100, true_params=true_params)

--- a/tests/unit/test_methods.py
+++ b/tests/unit/test_methods.py
@@ -100,7 +100,10 @@ def test_BOLFI_short(ma2, distribution_test):
     assert res_sampling_nuts.samples_array.shape[1] == 2
     assert len(res_sampling_nuts.samples_array) == n_samples // 2 * n_chains
 
-    res_sampling_metropolis = bolfi.sample(n_samples, n_chains=n_chains, algorithm='metropolis',sigma_proposals=np.ones(2))
+    res_sampling_metropolis = bolfi.sample(n_samples,
+                                           n_chains=n_chains,
+                                           algorithm='metropolis',
+                                           sigma_proposals={'t1': 0.2, 't2': 0.1})
     assert res_sampling_metropolis.samples_array.shape[1] == 2
     assert len(res_sampling_metropolis.samples_array) == n_samples // 2 * n_chains
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -6,7 +6,7 @@ import scipy.stats as ss
 
 import elfi
 from elfi.examples.ma2 import get_model
-from elfi.methods.bo.utils import minimize, stochastic_optimization
+from elfi.methods.bo.utils import CostFunction, minimize, stochastic_optimization
 from elfi.methods.density_ratio_estimation import DensityRatioEstimation
 from elfi.methods.utils import (GMDistribution, normalize_weights, numgrad, numpy_to_python_type,
                                 sample_object_to_dict, weighted_sample_quantile, weighted_var)
@@ -282,3 +282,21 @@ class TestDensityRatioEstimation:
 
         assert np.max(np.abs(test_w - test_w_estim)) < 0.1
         assert np.abs(np.max(test_w) - densratio.max_ratio()) < 0.1
+
+class TestCostFunction:
+
+    def test_evaluate(self):
+        def fun(x):
+            return x[0]**2 + (x[1] - 1)**4
+        
+        cost = CostFunction(elfi.tools.vectorize(fun), None, scale=10)
+        x = np.array([0.5, 0.5])
+        assert np.isclose(10 * fun(x), cost.evaluate(x))
+
+    def test_evaluate_gradient(self):
+        def grad(x):
+            return np.array([2 * x[0], 4 * (x[1] - 1)**3])
+
+        cost = CostFunction(None, elfi.tools.vectorize(grad), scale=10)
+        x = np.array([0.5, 0.5])
+        assert np.allclose(10 * grad(x), cost.evaluate_gradient(x))

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,5 @@
 [tox]
-envlist = py27, py35, flake8
-; envlist = py26, py27, py33, py34, py35, flake8
+envlist = py36, py37, py38, flake8
 
 [testenv:flake8]
 basepython=python


### PR DESCRIPTION
- Modify Lotka-Volterra model's priors as many methods do not support discrete random variables.
- Fix acquisition index in state plot
- Reformat `summary()` for `Sample(ParameterInferenceResult)`
- Fix linting in `arch.py`
- Add summary statistics to Lotka-Volterra model
- Add boolean `observation_noise` option to `lotka_volterra`
- Add parameter names as an optional input in model prior and fix the parameter order in priors used in BOLFI and BOLFIRE
- Add feature names as an optional input and make training data size a required input in BOLFIRE
- Fix the observed property in simulator nodes
- Fix default outputs in generate
- Add docstring description to ARCH-model
- Make MAP estimates calculation in BOLFIRE optional and based on log-posterior
- Use batch system to run simulations in BOLFIRE
- Use `target_model.parameter_names` from instead of `model.parameter_names` in `BOLFIRE`
- Extract BO results using `target_model.parameter_names` from instead of `model.parameter_names`
- Update tox.ini
- Add option to use additive acquisition cost in LCBSC
- Change sigma_proposals-input in metropolis from list to dict
- Fix is_array in utils
- Fix acq_noise_var-bug in acquisition.py. Influenced BOLFI.