### PR TITLE
Fix daycare example

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,8 @@
 Changelog
 =========
 
+- Fix multidimensional indexing in daycare example
+
 0.8.4 (2021-06-13)
 ------------------
 - Modify Lotka-Volterra model's priors as many methods do not support discrete random variables.

--- a/elfi/examples/daycare.py
+++ b/elfi/examples/daycare.py
@@ -133,7 +133,7 @@ def daycare(t1, t2, t3, n_dcc=29, n_ind=53, n_strains=33, freq_strains_commun=No
 
         # update state, need to find the correct indices first
         ind_transit = ind_b_dcc + list(np.unravel_index(ind_transit.ravel(), (n_ind, n_strains)))
-        state[ind_transit] = np.logical_not(state[ind_transit])
+        state[tuple(ind_transit)] = np.logical_not(state[tuple(ind_transit)])
 
     # observation model: simply take the first n_obs individuals
     state_obs = state[:, :, :n_obs, :]


### PR DESCRIPTION
#### Summary:

update multidimensional indexing with a non-tuple sequence `arr[seq]` to `arr[tuple(seq)]` in the daycare example. otherwise the example does not work when tested with python 3.8. this is because the test uses numpy 1.23.0 where multidimensional indexing with non-tuple values is not allowed, see [release notes](https://numpy.org/devdocs/release/1.23.0-notes.html#expired-deprecations).

#### Please make sure

- [x] You have updated the CHANGELOG.rst
- [x] You have provided a short summary of your changes (see previous section)
- [x] You have listed the copyright holder for the work you are submitting (see next section)

If your contribution adds, removes or somehow changes the functional behavior of the package, please check that

- [ ] You have included or updated all the relevant documentation 
- [ ] You have added appropriate unit tests to ensure the new features behave as expected

and the proposed changes pass all unit tests (check step 6 of CONTRIBUTING.rst for details)

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD3 (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
