### PR TITLE
BSL remove likelihood estimation node

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,7 @@
 Changelog
 =========
 
+- Remove synthetic likelihood node and update BSL data collection
 - Add GP classifier for ratio estimation
 - Fix multidimensional indexing in daycare example
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -28,7 +28,6 @@ Below is the API for creating generative models.
    elfi.Discrepancy
    elfi.Distance
    elfi.AdaptiveDistance
-   elfi.SyntheticLikelihood
 
 **Other**
 

--- a/elfi/examples/ar1.py
+++ b/elfi/examples/ar1.py
@@ -75,7 +75,6 @@ def get_model(n_obs=200, true_params=None, seed_obs=None):
     elfi.Summary(identity, m['AR1'], name='identity')
     # NOTE: AR(1) written for BSL, distance node included but not well tested
     elfi.Distance('euclidean', m['identity'], name='d')
-    elfi.SyntheticLikelihood("bsl", m['identity'], name="SL")
 
     logger.info("Generated observations with true parameters "
                 "t1: %.1f, t2: %.3f, t3: %.1f, ", *true_params)

--- a/elfi/examples/mg1.py
+++ b/elfi/examples/mg1.py
@@ -97,8 +97,6 @@ def get_model(n_obs=50, true_params=None, seed_obs=None):
     # NOTE: M/G/1 written for BSL, distance node included but not well tested
     elfi.Distance('euclidean', m['log_identity'], name='d')
 
-    elfi.SyntheticLikelihood("bsl", m['log_identity'], name="SL")
-
     logger.info("Generated observations with true parameters "
                 "t1: %.1f, t2: %.3f, t3: %.1f, ", *true_params)
 

--- a/elfi/examples/stochastic_volatility_model.py
+++ b/elfi/examples/stochastic_volatility_model.py
@@ -137,7 +137,6 @@ def get_model(n_obs=50, true_params=None, seed_obs=None, parallelise=False,
     elfi.Summary(identity,  m['a_svm'], name="identity")
     # NOTE: SVM written for BSL, distance node included but not well tested
     elfi.Distance('euclidean', m['identity'], name='d')
-    elfi.SyntheticLikelihood("semibsl", m['identity'], name="SL")
 
     logger.info("Generated observations with true parameters "
                 "t1: %.1f, t2: %.3f, t3: %.1f, ", *true_params)

--- a/elfi/examples/toad.py
+++ b/elfi/examples/toad.py
@@ -239,7 +239,6 @@ def get_model(n_obs=None, true_params=None, seed_obs=None, parallelise=True,
     sum_stats = elfi.Summary(compute_summaries, m['toad'], name='S')
     # NOTE: toad written for BSL, distance node included but not tested
     elfi.Distance('euclidean', sum_stats, name='d')
-    elfi.SyntheticLikelihood('semiBsl', m['S'], name='SL')
 
     logger.info("Generated observations with true parameters "
                 "t1: %.1f, t2: %.3f, t3: %.1f, ", *true_params)

--- a/elfi/methods/bsl/pdf_methods.py
+++ b/elfi/methods/bsl/pdf_methods.py
@@ -30,9 +30,8 @@ def semibsl_likelihood(shrinkage=None, penalty=None, whitening=None):
                    whitening=whitening)
 
 
-def misspec_likelihood(adjustment, tau=0.5, w=1, max_iter=1000, random_state=None):
-    return partial(syn_likelihood_misspec, adjustment=adjustment, tau=tau, w=w,
-                   max_iter=max_iter, random_state=random_state)
+def misspec_likelihood(adjustment, tau=0.5, w=1, max_iter=1000):
+    return partial(syn_likelihood_misspec, adjustment=adjustment, tau=tau, w=w, max_iter=max_iter)
 
 
 # likelihood estimation methods

--- a/elfi/methods/bsl/pdf_methods.py
+++ b/elfi/methods/bsl/pdf_methods.py
@@ -168,9 +168,8 @@ def gaussian_syn_likelihood_ghurye_olkin(ssx, ssy):
 
     return np.array([loglik])
 
-# TODO tkde appears unused -> ask about it
-def semi_param_kernel_estimate(ssx, ssy, shrinkage=None, penalty=None,
-                               whitening=None, tkde=False):
+
+def semi_param_kernel_estimate(ssx, ssy, shrinkage=None, penalty=None, whitening=None):
     """Calculate the semiparametric posterior logpdf.
 
     Uses the semi-parametric log likelihood
@@ -213,7 +212,6 @@ def semi_param_kernel_estimate(ssx, ssy, shrinkage=None, penalty=None,
     y_u = np.zeros(ns)
     sim_eta = np.zeros((n, ns))  # only used for wsemibsl
     eta_cov = None
-    jacobian = 1  # used for TKDE method
     for j in range(ns):
         ssx_j = ssx[:, j].flatten()
         y = ssy[j]
@@ -221,7 +219,7 @@ def semi_param_kernel_estimate(ssx, ssy, shrinkage=None, penalty=None,
         # NOTE: bw_method - "silverman" is being used here is slightly
         #       different than "nrd0" - silverman's rule of thumb in R.
         kernel = ss.kde.gaussian_kde(ssx_j, bw_method="silverman")
-        logpdf_y[j] = kernel.logpdf(y) * np.abs(jacobian)
+        logpdf_y[j] = kernel.logpdf(y)
 
         y_u[j] = kernel.integrate_box_1d(np.NINF, y)
 

--- a/elfi/methods/bsl/pdf_methods.py
+++ b/elfi/methods/bsl/pdf_methods.py
@@ -30,8 +30,9 @@ def semibsl_likelihood(shrinkage=None, penalty=None, whitening=None):
                    whitening=whitening)
 
 
-def misspec_likelihood(adjustment, tau=0.5, w=1, max_iter=1000):
-    return partial(syn_likelihood_misspec, adjustment=adjustment, tau=tau, w=w, max_iter=max_iter)
+def misspec_likelihood(adjustment, tau=0.5, w=1, max_iter=1000, random_state=None):
+    return partial(syn_likelihood_misspec, adjustment=adjustment, tau=tau, w=w,
+                   max_iter=max_iter, random_state=random_state)
 
 
 # likelihood estimation methods
@@ -240,7 +241,7 @@ def semi_param_kernel_estimate(ssx, ssy, shrinkage=None, penalty=None,
 
 
 def syn_likelihood_misspec(ssx, ssy, prev_state, adjustment="variance", tau=0.5,
-                           w=1, max_iter=1000):
+                           w=1, max_iter=1000, random_state=None):
     """Calculate the posterior logpdf using the standard synthetic likelihood.
 
     Parameters
@@ -290,7 +291,8 @@ def syn_likelihood_misspec(ssx, ssy, prev_state, adjustment="variance", tau=0.5,
                                              sample_cov=prev_sample_cov,
                                              tau=tau,
                                              w=w,
-                                             max_iter=max_iter
+                                             max_iter=max_iter,
+                                             random_state=random_state
                                              )
         if adjustment == "variance":
             gamma, prev_iter_loglik = slice_gamma_variance(ssy,
@@ -300,7 +302,8 @@ def syn_likelihood_misspec(ssx, ssy, prev_state, adjustment="variance", tau=0.5,
                                                  sample_cov=prev_sample_cov,
                                                  tau=tau,
                                                  w=w,
-                                                 max_iter=max_iter
+                                                 max_iter=max_iter,
+                                                 random_state=random_state
                                                  )
 
     if s1 == dim_ss:  # obs as columns

--- a/elfi/methods/bsl/pdf_methods.py
+++ b/elfi/methods/bsl/pdf_methods.py
@@ -18,23 +18,52 @@ from elfi.methods.bsl.slice_gamma_variance import slice_gamma_variance
 logger = logging.getLogger(__name__)
 
 
-# convenience functions for likelihood estimation setup
-
 def bsl_likelihood(shrinkage=None, penalty=None, whitening=None, standardise=False):
+    """Return gaussian_syn_likelihood with selected setup.
+
+    Parameters
+    ----------
+    see gaussian_syn_likelihood
+
+    Returns
+    -------
+    callable
+
+    """
     return partial(gaussian_syn_likelihood, shrinkage=shrinkage, penalty=penalty,
                    whitening=whitening, standardise=standardise)
 
 
 def semibsl_likelihood(shrinkage=None, penalty=None, whitening=None):
+    """Return semi_param_kernel_estimate with selected setup.
+
+    Parameters
+    ----------
+    see semi_param_kernel_estimate
+
+    Returns
+    -------
+    callable
+
+    """
     return partial(semi_param_kernel_estimate, shrinkage=shrinkage, penalty=penalty,
                    whitening=whitening)
 
 
 def misspec_likelihood(adjustment, tau=0.5, w=1, max_iter=1000):
+    """Return syn_likelihood_misspec with selected setup.
+
+    Parameters
+    ----------
+    see syn_likelihood_misspec
+
+    Returns
+    -------
+    callable
+
+    """
     return partial(syn_likelihood_misspec, adjustment=adjustment, tau=tau, w=w, max_iter=max_iter)
 
-
-# likelihood estimation methods
 
 def gaussian_syn_likelihood(ssx, ssy, shrinkage=None, penalty=None, whitening=None,
                             standardise=False):
@@ -57,7 +86,7 @@ def gaussian_syn_likelihood(ssx, ssy, shrinkage=None, penalty=None, whitening=No
         The whitening matrix that can be used to estimate the sample
         covariance matrix in 'BSL' or 'semiBsl' methods. Whitening
         transformation helps decorrelate the summary statistics allowing
-        for heaving shrinkage to be applied (hence smaller batch_size).
+        for heaving shrinkage to be applied (hence smaller simulation count).
     standardise : bool, optional
         Used with shrinkage method "glasso".
 
@@ -155,7 +184,7 @@ def semi_param_kernel_estimate(ssx, ssy, shrinkage=None, penalty=None,
 
     Parameters
     ----------
-    ssx : np.array  
+    ssx : np.array
         Simulated summaries at x.
     ssy : np.array
         Observed summaries.
@@ -170,7 +199,7 @@ def semi_param_kernel_estimate(ssx, ssy, shrinkage=None, penalty=None,
         The whitening matrix that can be used to estimate the sample
         covariance matrix in 'BSL' or 'semiBsl' methods. Whitening
         transformation helps decorrelate the summary statistics allowing
-        for heaving shrinkage to be applied (hence smaller batch_size).
+        for heaving shrinkage to be applied (hence smaller simulation count).
 
     Returns
     -------
@@ -197,15 +226,11 @@ def semi_param_kernel_estimate(ssx, ssy, shrinkage=None, penalty=None,
         y_u[j] = kernel.integrate_box_1d(np.NINF, y)
 
         if whitening is not None:
-            # TODO? Commented out very inefficient for large batch_size
+            # TODO? Commented out very inefficient for large simulation count
             # sim_eta[:, j] = [ss.norm.ppf(kernel.integrate_box_1d(np.NINF,
             #                                                      ssx_i))
             #                  for ssx_i in ssx_j]
             sim_eta[:, j] = ss.norm.ppf(ss.rankdata(ssx_j)/(n+1))
-
-    # Below is exit point for helper function for estimate_whitening_matrix
-    if not hasattr(whitening, 'shape') and whitening == "whitening":
-        return sim_eta
 
     rho_hat = grc(ssx)
 
@@ -245,7 +270,7 @@ def syn_likelihood_misspec(ssx, ssy, prev_state, adjustment="variance", tau=0.5,
 
     Parameters
     ----------
-    ssx : np.array  
+    ssx : np.array
         Simulated summaries at x
     ssy : np.array
         Observed summaries.
@@ -284,26 +309,26 @@ def syn_likelihood_misspec(ssx, ssy, prev_state, adjustment="variance", tau=0.5,
                 gamma = np.repeat(tau, dim_ss)
         if adjustment == "mean":
             gamma, prev_iter_loglik = slice_gamma_mean(ssy,
-                                             loglik=prev_iter_loglik,
-                                             gamma=gamma,
-                                             sample_mean=prev_sample_mean,
-                                             sample_cov=prev_sample_cov,
-                                             tau=tau,
-                                             w=w,
-                                             max_iter=max_iter,
-                                             random_state=random_state
-                                             )
+                                                       loglik=prev_iter_loglik,
+                                                       gamma=gamma,
+                                                       sample_mean=prev_sample_mean,
+                                                       sample_cov=prev_sample_cov,
+                                                       tau=tau,
+                                                       w=w,
+                                                       max_iter=max_iter,
+                                                       random_state=random_state
+                                                       )
         if adjustment == "variance":
             gamma, prev_iter_loglik = slice_gamma_variance(ssy,
-                                                 loglik=prev_iter_loglik,
-                                                 gamma=gamma,
-                                                 sample_mean=prev_sample_mean,
-                                                 sample_cov=prev_sample_cov,
-                                                 tau=tau,
-                                                 w=w,
-                                                 max_iter=max_iter,
-                                                 random_state=random_state
-                                                 )
+                                                           loglik=prev_iter_loglik,
+                                                           gamma=gamma,
+                                                           sample_mean=prev_sample_mean,
+                                                           sample_cov=prev_sample_cov,
+                                                           tau=tau,
+                                                           w=w,
+                                                           max_iter=max_iter,
+                                                           random_state=random_state
+                                                           )
 
     if s1 == dim_ss:  # obs as columns
         ssx = np.transpose(ssx)

--- a/elfi/methods/bsl/pre_sample_methods.py
+++ b/elfi/methods/bsl/pre_sample_methods.py
@@ -1,0 +1,121 @@
+"""This module contains helper methods used to configure BSL."""
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+import elfi.visualization.visualization as vis
+from elfi.methods.bsl.pdf_methods import gaussian_syn_likelihood
+from elfi.methods.utils import batch_to_arr2d
+from elfi.model.utils import get_summary_names
+
+def plot_summary_statistics(model, theta, n_samples, summary_names=None):
+    """Plot simulated summary statistics at parameter values theta.
+
+    Intent is to check distribution shape, particularly normality, for BSL inference.
+
+    Parameters
+    ----------
+    model: elfi.Model
+        Model which is explored.
+    theta : dict or np.array
+        Model parameters which are used to run the simulations.
+    n_samples: int
+        Number of simulations.
+    summary_names : list, optional
+        Summaries which are plotted. Defaults to all summary statistics in the model.
+
+    """
+    params = theta if isinstance(theta, dict) else dict(zip(theta, model.parameter_names))
+    summary_names = summary_names or get_summary_names(model)
+    ssx = model.generate(n_samples, outputs=summary_names, with_values=params)
+
+    ssx_dict = {}
+    for output_name in summary_names:
+        if ssx[output_name].ndim > 1 and ssx[output_name].shape[1] > 1:
+            ns = ssx[output_name].shape[1]
+            for i in range(ns):
+                new_output_name = output_name + '_' + str(i+1)
+                ssx_dict[new_output_name] = ssx[output_name][:, i]
+        else:
+            ssx_dict[output_name] = ssx[output_name]
+
+    vis.plot_summaries(ssx_dict)
+
+
+def plot_covariance_matrix(model, theta, n_samples, summary_names=None, corr=False, 
+                           precision=False, colorbar=True):
+    """Plot correlation matrix of summary statistics.
+
+    Check sparsity of covariance (or correlation) matrix.
+    Useful to determine if shrinkage estimation could be applied
+    which can reduce the number of model simulations required. 
+    
+    Parameters
+    ----------
+    model: elfi.Model
+        Model which is explored.
+    theta : dict or np.array
+        Model parameters which are used to run the simulations.
+    n_samples: int
+        Number of simulations.
+    summary_names : list, optional
+        Summaries which are plotted. Defaults to all summary statistics in the model.
+    corr : bool
+        True -> correlation, False -> covariance
+    precision: bool
+        True -> precision matrix, False -> covariance/corr
+    
+    """
+    params = theta if isinstance(theta, dict) else dict(zip(theta, model.parameter_names))
+    summary_names = summary_names or get_summary_names(model)
+    ssx = model.generate(n_samples, outputs=summary_names, with_values=params)
+    ssx_arr = batch_to_arr2d(ssx, summary_names)
+
+    sample_cov = np.cov(ssx_arr, rowvar=False)
+    if corr:
+        sample_cov = np.corrcoef(sample_cov)  # correlation matrix                              
+    if precision:
+        sample_cov = np.linalg.inv(sample_cov)
+                
+    fig = plt.figure()
+    ax = plt.subplot(111)
+    
+    cax = ax.matshow(sample_cov)
+    if colorbar:
+        fig.colorbar(cax)
+
+
+def log_SL_stdev(model, theta, sl_samples, M, sl_method=None, summary_names=None):
+    """Estimate the standard deviation of the log SL.
+    
+    Parameters
+    ----------
+    model: elfi.Model
+        Model which is explored.
+    theta : dict or np.array
+        Model parameters which are used to run the simulations.
+    sl_samples : int
+        Number of simulations used in synthetic likelihood estimation.
+    M : int
+        Number of log-likelihoods to estimate standard deviation.
+    sl_method : callable
+        Synthetic likelihood estimation method. Defaults to gaussian_syn_likelihood.
+    summary_names : list
+           Summaries which are plotted. Defaults to all summary statistics in the model.
+
+    Returns
+    -------
+    float
+
+    """
+    params = theta if isinstance(theta, dict) else dict(zip(theta, model.parameter_names))
+    sl_method = sl_method or gaussian_syn_likelihood
+    summary_names = summary_names or get_summary_names(model)
+    observed = np.column_stack([model[node].observed for node in summary_names])
+
+    ll = np.zeros(M)
+    for i in range(M):
+        ssx = model.generate(sl_samples, outputs=summary_names, with_values=params)
+        ssx_arr = batch_to_arr2d(ssx, summary_names)
+        ll[i] = sl_method(ssx_arr, observed)
+    return np.std(ll)

--- a/elfi/methods/bsl/pre_sample_methods.py
+++ b/elfi/methods/bsl/pre_sample_methods.py
@@ -1,4 +1,4 @@
-"""This module contains helper methods used to configure BSL."""
+"""This module contains methods for assessing selected features and simulation count."""
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -6,10 +6,10 @@ import numpy as np
 import elfi.visualization.visualization as vis
 from elfi.methods.bsl.pdf_methods import gaussian_syn_likelihood
 from elfi.methods.utils import batch_to_arr2d
-from elfi.model.utils import get_summary_names
 
-def plot_summary_statistics(model, theta, n_samples, summary_names=None):
-    """Plot simulated summary statistics at parameter values theta.
+
+def plot_simulated(model, theta, n_sim, feature_names):
+    """Plot simulated feature values at theta.
 
     Intent is to check distribution shape, particularly normality, for BSL inference.
 
@@ -19,18 +19,18 @@ def plot_summary_statistics(model, theta, n_samples, summary_names=None):
         Model which is explored.
     theta : dict or np.array
         Model parameters which are used to run the simulations.
-    n_samples: int
+    n_sim: int
         Number of simulations.
-    summary_names : list, optional
-        Summaries which are plotted. Defaults to all summary statistics in the model.
+    feature_names : list or str
+        Features which are plotted.
 
     """
     params = theta if isinstance(theta, dict) else dict(zip(theta, model.parameter_names))
-    summary_names = summary_names or get_summary_names(model)
-    ssx = model.generate(n_samples, outputs=summary_names, with_values=params)
+    feature_names = [feature_names] if isinstance(feature_names, str) else feature_names
+    ssx = model.generate(n_sim, outputs=feature_names, with_values=params)
 
     ssx_dict = {}
-    for output_name in summary_names:
+    for output_name in feature_names:
         if ssx[output_name].ndim > 1 and ssx[output_name].shape[1] > 1:
             ns = ssx[output_name].shape[1]
             for i in range(ns):
@@ -42,66 +42,68 @@ def plot_summary_statistics(model, theta, n_samples, summary_names=None):
     vis.plot_summaries(ssx_dict)
 
 
-def plot_covariance_matrix(model, theta, n_samples, summary_names=None, corr=False, 
+def plot_covariance_matrix(model, theta, n_sim, feature_names, corr=False,
                            precision=False, colorbar=True):
-    """Plot correlation matrix of summary statistics.
+    """Plot correlation matrix of simulated features.
 
     Check sparsity of covariance (or correlation) matrix.
     Useful to determine if shrinkage estimation could be applied
-    which can reduce the number of model simulations required. 
-    
+    which can reduce the number of model simulations required.
+
     Parameters
     ----------
     model: elfi.Model
         Model which is explored.
     theta : dict or np.array
         Model parameters which are used to run the simulations.
-    n_samples: int
+    n_sim : int
         Number of simulations.
-    summary_names : list, optional
-        Summaries which are plotted. Defaults to all summary statistics in the model.
-    corr : bool
+    feature_names : list or str
+        Features which are plotted.
+    corr : bool, optional
         True -> correlation, False -> covariance
-    precision: bool
+    precision: bool, optional
         True -> precision matrix, False -> covariance/corr
-    
+    colorbar : bool, optional
+        Whether to include colorbar in the plot.
+
     """
     params = theta if isinstance(theta, dict) else dict(zip(theta, model.parameter_names))
-    summary_names = summary_names or get_summary_names(model)
-    ssx = model.generate(n_samples, outputs=summary_names, with_values=params)
-    ssx_arr = batch_to_arr2d(ssx, summary_names)
+    feature_names = [feature_names] if isinstance(feature_names, str) else feature_names
+    ssx = model.generate(n_sim, outputs=feature_names, with_values=params)
+    ssx_arr = batch_to_arr2d(ssx, feature_names)
 
     sample_cov = np.cov(ssx_arr, rowvar=False)
     if corr:
-        sample_cov = np.corrcoef(sample_cov)  # correlation matrix                              
+        sample_cov = np.corrcoef(sample_cov)  # correlation matrix
     if precision:
         sample_cov = np.linalg.inv(sample_cov)
-                
+
     fig = plt.figure()
     ax = plt.subplot(111)
-    
+
     cax = ax.matshow(sample_cov)
     if colorbar:
         fig.colorbar(cax)
 
 
-def log_SL_stdev(model, theta, sl_samples, M, sl_method=None, summary_names=None):
+def log_SL_stdev(model, theta, n_sim, feature_names, likelihood=None, M=20):
     """Estimate the standard deviation of the log SL.
-    
+
     Parameters
     ----------
     model: elfi.Model
         Model which is explored.
     theta : dict or np.array
         Model parameters which are used to run the simulations.
-    sl_samples : int
-        Number of simulations used in synthetic likelihood estimation.
-    M : int
-        Number of log-likelihoods to estimate standard deviation.
-    sl_method : callable
+    n_sim : int
+        Number of simulations used to calculate a synthetic likelihood estimate.
+    feature_names : list or str
+        Features used in synthetic likelihood estimation.
+    likelihood : callable, optional
         Synthetic likelihood estimation method. Defaults to gaussian_syn_likelihood.
-    summary_names : list
-           Summaries which are plotted. Defaults to all summary statistics in the model.
+    M : int, optional
+        Number of log-likelihoods to estimate standard deviation.
 
     Returns
     -------
@@ -109,13 +111,13 @@ def log_SL_stdev(model, theta, sl_samples, M, sl_method=None, summary_names=None
 
     """
     params = theta if isinstance(theta, dict) else dict(zip(theta, model.parameter_names))
-    sl_method = sl_method or gaussian_syn_likelihood
-    summary_names = summary_names or get_summary_names(model)
-    observed = np.column_stack([model[node].observed for node in summary_names])
+    feature_names = [feature_names] if isinstance(feature_names, str) else feature_names
+    observed = np.column_stack([model[node].observed for node in feature_names])
+    likelihood = likelihood or gaussian_syn_likelihood
 
     ll = np.zeros(M)
     for i in range(M):
-        ssx = model.generate(sl_samples, outputs=summary_names, with_values=params)
-        ssx_arr = batch_to_arr2d(ssx, summary_names)
-        ll[i] = sl_method(ssx_arr, observed)
+        ssx = model.generate(n_sim, outputs=feature_names, with_values=params)
+        ssx_arr = batch_to_arr2d(ssx, feature_names)
+        ll[i] = likelihood(ssx_arr, observed)
     return np.std(ll)

--- a/elfi/methods/bsl/pre_sample_methods.py
+++ b/elfi/methods/bsl/pre_sample_methods.py
@@ -8,7 +8,7 @@ from elfi.methods.bsl.pdf_methods import gaussian_syn_likelihood
 from elfi.methods.utils import batch_to_arr2d
 
 
-def plot_simulated(model, theta, n_sim, feature_names):
+def plot_features(model, theta, n_sim, feature_names):
     """Plot simulated feature values at theta.
 
     Intent is to check distribution shape, particularly normality, for BSL inference.

--- a/elfi/methods/bsl/select_penalty.py
+++ b/elfi/methods/bsl/select_penalty.py
@@ -6,17 +6,15 @@ import numpy as np
 from sklearn.exceptions import ConvergenceWarning
 from sklearn.utils._testing import ignore_warnings
 
-import elfi
-from elfi.methods.bsl.pdf_methods import gaussian_syn_likelihood, semi_param_kernel_estimate
+from elfi.methods.bsl.pdf_methods import gaussian_syn_likelihood
 from elfi.methods.utils import batch_to_arr2d
-from elfi.model.elfi_model import ElfiModel, Summary
 
 logger = logging.getLogger(__name__)
 
 
 @ignore_warnings(category=ConvergenceWarning)  # graphical lasso bad values
-def select_penalty(model, batch_size, theta, summary_names=None, lmdas=None,
-                   M=20, sigma=1.5, method="bsl", shrinkage="glasso",
+def select_penalty(model, n_sim, theta, feature_names, likelihood=None,
+                   lmdas=None, M=20, sigma=1.5, shrinkage="glasso",
                    whitening=None, seed=None, verbose=False):
     """Select the penalty value to use within an MCMC BSL algorithm.
 
@@ -28,32 +26,30 @@ def select_penalty(model, batch_size, theta, summary_names=None, lmdas=None,
     ----------
     model : elfi.ElfiModel
         The ELFI graph used by the algorithm
-    batch_size : int, np.array
-        Then number of simulations. If array finds closest penalty of
-        each batch_size
-    theta : np.array
+    n_sim : int or np.array
+        The number of simulations. If array, selects penalty for each simulation count.
+    theta : dict or np.array
         Parameter point where all loglikelihoods are calculated.
-    summary_names : str or optional, 
-        Summaries used in synthetic likelihood estimation. Defaults to all summary statistics.
-    M : int, optional
-        The number of repeats at the same lambda and batch_size values
-        to estimate the stdev of the log-likelihood
+    feature_names : str or list
+        Features used in synthetic likelihood estimation.
+    likelihood : callable, optional
+        Synthetic likelihood estimation method. Defaults to gaussian_syn_likelihood.
     lmdas : np.array, optional
         The penalties values to test over
+    M : int, optional
+        The number of repeats at the same lambda and n_sim values
+        to estimate the stdev of the log-likelihood
     sigma : float
         A given standard deviation value (should be between 1 and 2)
         where the lambda value with the closest estimated loglik stdev
         to sigma is returned.
-    method : str, optional
-        Specifies the bsl method to approximate the likelihood.
-        Defaults to "bsl".
     shrinkage : str, optional
         The shrinkage method to be used with the penalty param.
     whitening : np.array of shape (m x m) - m = num of summary statistics
         The whitening matrix that can be used to estimate the sample
         covariance matrix in 'BSL' or 'semiBsl' methods. Whitening
         transformation helps decorrelate the summary statistics allowing
-        for heaving shrinkage to be applied (hence smaller batch_size).
+        for heaving shrinkage to be applied (hence smaller simulation count).
     seed : int, optional
         Seed for the data generation from the ElfiModel
     verbose : bool, optional
@@ -64,6 +60,12 @@ def select_penalty(model, batch_size, theta, summary_names=None, lmdas=None,
         The closest lambdas (for each batch_size passed in)
 
     """
+    param_values = theta if isinstance(theta, dict) else dict(zip(model.parameter_names, theta))
+    feature_names = [feature_names] if isinstance(feature_names, str) else feature_names
+    ssy = np.column_stack([model[node].observed for node in feature_names])
+
+    likelihood = likelihood or gaussian_syn_likelihood
+
     if lmdas is None:
         if shrinkage == "glasso":
             lmdas = list(np.exp(np.arange(-5.5, -1.5, 0.2)))
@@ -71,7 +73,7 @@ def select_penalty(model, batch_size, theta, summary_names=None, lmdas=None,
             lmdas = list((np.arange(0.2, 0.8, 0.02)))
 
     n_lambda = len(lmdas)
-    batch_size = np.array([batch_size]).flatten()
+    batch_size = np.array([n_sim]).flatten()
     ns = len(batch_size)
 
     ss = np.random.SeedSequence(seed)
@@ -79,25 +81,12 @@ def select_penalty(model, batch_size, theta, summary_names=None, lmdas=None,
 
     logliks = np.zeros((M, ns, n_lambda))
 
-    if summary_names is None:
-        summary_names = [node for node in model.nodes if isinstance(model[node], Summary)
-                         and not node.startswith('_')]
-        logger.info('Using all summary statistics in synthetic likelihood estimation.')
-    if isinstance(summary_names, str):
-        summary_names = [summary_names]
-    obs_ss = np.column_stack([model[summary_name].observed for summary_name in summary_names])
-
-    if isinstance(theta, dict):
-        param_values = theta
-    else:
-        param_values = dict(zip(model.parameter_names, theta))
-
     for m_iteration in range(M):  # for M logliks at same penalty and batch_size
         ssx = model.generate(max(batch_size),
-                             outputs=summary_names,
+                             outputs=feature_names,
                              with_values=param_values,
                              seed=child_seeds[m_iteration])
-        ssx_arr = batch_to_arr2d(ssx, summary_names)
+        ssx_arr = batch_to_arr2d(ssx, feature_names)
         for n_iteration in range(ns):
             idx = np.random.choice(max(batch_size),
                                    batch_size[n_iteration],
@@ -105,13 +94,12 @@ def select_penalty(model, batch_size, theta, summary_names=None, lmdas=None,
             ssx_n = ssx_arr[idx]
 
             for lmda_iteration in range(n_lambda):
-                sl_method_fn = _resolve_sl_method(method)
                 try:
-                    loglik = sl_method_fn(ssx_n,
-                                          obs_ss,
-                                          shrinkage=shrinkage,
-                                          penalty=lmdas[lmda_iteration],
-                                          whitening=whitening)
+                    loglik = likelihood(ssx_n,
+                                        ssy,
+                                        shrinkage=shrinkage,
+                                        penalty=lmdas[lmda_iteration],
+                                        whitening=whitening)
                 except FloatingPointError as err:
                     logger.warning('Floating point error: {}'.format(err))
                     loglik = np.NINF
@@ -128,20 +116,3 @@ def select_penalty(model, batch_size, theta, summary_names=None, lmdas=None,
         print('logliks: ', logliks)
         print('std_devs: ', std_devs)
     return closest_lmdas
-
-def _resolve_sl_method(sl_method):
-    
-    sl_method = sl_method.lower()
-    if sl_method == "bsl" or sl_method == "sbsl":
-        sl_method_fn = gaussian_syn_likelihood
-    elif sl_method == "semibsl":
-        sl_method_fn = semi_param_kernel_estimate
-    elif sl_method == "ubsl":
-        raise ValueError("Unbiased BSL does not use shrinkage/penalty.")
-    elif sl_method == "misspecbsl" or sl_method == "rbsl":
-        raise ValueError("Misspecified BSL does not use shrinkage/penalty.")
-    else:
-        raise ValueError("no method with name ", sl_method, " found")
-
-    return sl_method_fn
-

--- a/elfi/methods/bsl/select_penalty.py
+++ b/elfi/methods/bsl/select_penalty.py
@@ -57,7 +57,7 @@ def select_penalty(model, n_sim, theta, feature_names, likelihood=None,
 
     Returns
     -------
-        The closest lambdas (for each batch_size passed in)
+        The closest lambdas and standard deviation values (for each batch_size passed in)
 
     """
     param_values = theta if isinstance(theta, dict) else dict(zip(model.parameter_names, theta))
@@ -108,11 +108,13 @@ def select_penalty(model, n_sim, theta, feature_names, likelihood=None,
     # choose the lambda with the empirical s.d. of the log SL estimates
     # closest to sigma
     closest_lmdas = np.zeros(ns)
+    closest_std_devs = np.zeros(ns)
     for i in range(ns):
         std_devs = np.array([np.std(logliks[:, i, j]) for j in range(n_lambda)])
         closest_arg = np.argmin(np.abs(std_devs - sigma))
         closest_lmdas[i] = lmdas[closest_arg]
+        closest_std_devs[i] = std_devs[closest_arg]
     if verbose:
         print('logliks: ', logliks)
         print('std_devs: ', std_devs)
-    return closest_lmdas
+    return closest_lmdas, closest_std_devs

--- a/elfi/methods/bsl/slice_gamma_mean.py
+++ b/elfi/methods/bsl/slice_gamma_mean.py
@@ -33,7 +33,7 @@ def log_gamma_prior(x, tau=0.5):
 
 
 def slice_gamma_mean(ssy, loglik, gamma, sample_mean, sample_cov,
-                     tau=0.5, w=1.0, max_iter=1000):
+                     tau=0.5, w=1.0, max_iter=1000, random_state=None):
     """Slice sampler algorithm for mean adjustment gammas.
 
     Parameters
@@ -56,16 +56,18 @@ def slice_gamma_mean(ssy, loglik, gamma, sample_mean, sample_cov,
     max_iter : int, optional
         The maximum number of iterations for the stepping out and shrinking
         procedures for the slice sampler algorithm.
-    # TODO? needs random state
+    random_state : np.random.RandomState, optional
+
     Returns
     -------
     gamma_curr : np.array
 
     """
+    random_state = random_state or np.random
     gamma_curr = gamma
     std = np.sqrt(np.diag(sample_cov))
     for ii, gamma in enumerate(gamma_curr):
-        exp_u = np.random.exponential(1)
+        exp_u = random_state.exponential(1)
         target = loglik + log_gamma_prior(gamma_curr, tau=tau) - exp_u
 
         lower = gamma - w
@@ -110,7 +112,7 @@ def slice_gamma_mean(ssy, loglik, gamma, sample_mean, sample_cov,
         # shrink
         i = 0
         while (i < max_iter):
-            prop = np.random.uniform(lower, upper)
+            prop = random_state.uniform(lower, upper)
             gamma_prop = gamma_curr
             gamma_prop[ii] = prop
             sample_mean_prop = sample_mean + std * gamma_prop

--- a/elfi/methods/bsl/slice_gamma_mean.py
+++ b/elfi/methods/bsl/slice_gamma_mean.py
@@ -32,14 +32,14 @@ def log_gamma_prior(x, tau=0.5):
     return res
 
 
-def slice_gamma_mean(ssx, ssy, loglik, gamma, std, sample_mean, sample_cov,
+def slice_gamma_mean(ssy, loglik, gamma, sample_mean, sample_cov,
                      tau=0.5, w=1.0, max_iter=1000):
     """Slice sampler algorithm for mean adjustment gammas.
 
     Parameters
     ----------
-    ssx : np.array
-        Simulated summaries
+    ssy : np.array
+        Observed summaries
     loglik : np.float64
         Current log-likelihood
     gamma : np.array
@@ -63,6 +63,7 @@ def slice_gamma_mean(ssx, ssy, loglik, gamma, std, sample_mean, sample_cov,
 
     """
     gamma_curr = gamma
+    std = np.sqrt(np.diag(sample_cov))
     for ii, gamma in enumerate(gamma_curr):
         exp_u = np.random.exponential(1)
         target = loglik + log_gamma_prior(gamma_curr, tau=tau) - exp_u

--- a/elfi/methods/bsl/slice_gamma_variance.py
+++ b/elfi/methods/bsl/slice_gamma_variance.py
@@ -28,14 +28,14 @@ def log_gamma_prior(x, tau=0.5):
     return np.sum(ss.expon.logpdf(x, scale=tau))  # tau - inv rate param, scale inv of rate.
 
 
-def slice_gamma_variance(ssx, ssy, loglik, gamma, std, sample_mean, sample_cov,
+def slice_gamma_variance(ssy, loglik, gamma, sample_mean, sample_cov,
                          tau=0.5, w=1.0, max_iter=1000, random_state=None):
     """Slice sampler algorithm for variance adjustment gammas.
 
     Parameters
     ----------
-    ssx : np.array
-        Simulated summaries
+    ssy : np.array
+        Observed summaries
     loglik : np.float64
         Current log-likelihood
     gamma : np.array
@@ -60,6 +60,7 @@ def slice_gamma_variance(ssx, ssy, loglik, gamma, std, sample_mean, sample_cov,
     """
     random_state = random_state or np.random
     gamma_curr = gamma
+    std = np.sqrt(np.diag(sample_cov))
     for ii, gamma in enumerate(gamma_curr):
         target = loglik + log_gamma_prior(gamma_curr, tau) - \
             random_state.exponential(1)

--- a/elfi/methods/bsl/slice_gamma_variance.py
+++ b/elfi/methods/bsl/slice_gamma_variance.py
@@ -45,7 +45,7 @@ def slice_gamma_variance(ssy, loglik, gamma, sample_mean, sample_cov,
     sample_cov : np.array
         sample cov from previous iteration
     tau : float, optional
-        Scale (or inverse rate) parameter of the Laplace prior
+        Scale (or inverse rate) parameter of the exponential prior
         distribution for gamma.
     w : float, optional
         Step size used for stepping out procedure in slice sampler.

--- a/elfi/methods/bsl/slice_gamma_variance.py
+++ b/elfi/methods/bsl/slice_gamma_variance.py
@@ -52,7 +52,8 @@ def slice_gamma_variance(ssy, loglik, gamma, sample_mean, sample_cov,
     max_iter : int, optional
         The maximum number of iterations for the stepping out and shrinking
         procedures for the slice sampler algorithm.
-    # TODO? needs random_state
+    random_state : np.random.RandomState, optional
+
     Returns
     -------
     gamma_curr : np.array
@@ -89,7 +90,7 @@ def slice_gamma_variance(ssy, loglik, gamma, sample_mean, sample_cov,
         # shrink
         i = 0
         while (i < max_iter):
-            prop = np.random.uniform(lower, upper)
+            prop = random_state.uniform(lower, upper)
             gamma_prop = np.array(gamma_curr, dtype="float64")
             gamma_prop[ii] = prop
             sample_cov_upper = sample_cov + np.diag((std * gamma_prop) ** 2)

--- a/elfi/methods/inference/bsl.py
+++ b/elfi/methods/inference/bsl.py
@@ -623,23 +623,20 @@ class BSL(Sampler):
             Theta estimate where all simulations are run.
 
         """
-        m = self.model.copy()
-        bsl_temp = elfi.BSL(m[self.bsl_name],
-                            output_names=self.summary_names,
-                            batch_size=batch_size)
+        model = self.model.copy()
+        param_values = dict(zip(model.parameter_names, theta_point))
+
+        ssx = model.generate(batch_size,
+                             outputs=self.summary_names,
+                             with_values=param_values)
 
         ssx_dict = {}
-        bsl_temp.sample(1)
-        for output_name in bsl_temp.output_names:
-            if output_name in self.summary_names:
-                if bsl_temp.state[output_name][0].ndim > 1:
-                    n, ns = bsl_temp.state[output_name][0].shape[0:2]
-                    for i in range(ns):
-                        new_output_name = output_name + '_' + str(i)
-                        ssx_dict[new_output_name] =  \
-                            bsl_temp.state[output_name][0][:, i]
-                else:
-                    ssx_dict[output_name] = bsl_temp.state[output_name]
+        for output_name in self.summary_names:
+            if ssx[output_name].ndim > 1:
+                ns = ssx[output_name].shape[1]
+                for i in range(ns):
+                    new_output_name = output_name + '_' + str(i)
+                    ssx_dict[new_output_name] = ssx[output_name][:, i]
 
         return vis.plot_summaries(ssx_dict, self.summary_names)
 

--- a/elfi/methods/inference/bsl.py
+++ b/elfi/methods/inference/bsl.py
@@ -104,6 +104,8 @@ class BSL(ParameterInference):
         self.sigma_proposals = sigma_proposals
         self.burn_in = burn_in
         self.logit_transform_bound = logit_transform_bound
+        if self.logit_transform_bound is not None:
+            self.logit_transform_bound = np.array(self.logit_transform_bound)
 
         # allow custom parameter order
         self.param_names = param_names or self.parameter_names
@@ -348,8 +350,8 @@ class BSL(ParameterInference):
         ----------
         theta : np.array
             Array of parameter values
-        bound: list of np.arrays
-            List of bounds for each parameter
+        bound: np.array
+            Bounds for each parameter
 
         Returns
         -------
@@ -387,8 +389,8 @@ class BSL(ParameterInference):
         ----------
         thetaTilde : np.array
             Array of parameter values
-        bound: list of np.arrays
-            List of bounds for each parameter
+        bound: np.array
+            Bounds for each parameter
 
         Returns
         -------
@@ -426,8 +428,9 @@ class BSL(ParameterInference):
         Parameters
         ----------
         thetaTilde : np.array
-        bound: list of np.arrays
-            List of bounds for each parameter
+            Array of parameter values
+        bound: np.array
+            Bounds for each parameter
 
         Returns
         ----------

--- a/elfi/methods/inference/bsl.py
+++ b/elfi/methods/inference/bsl.py
@@ -176,7 +176,7 @@ class BSL(ParameterInference):
         batch: dict
 
         """
-        batch_parameters = np.repeat(self._params, self.batch_size, axis=0)
+        batch_parameters = np.repeat(np.atleast_2d(self._params), self.batch_size, axis=0)
         return arr2d_to_batch(batch_parameters, self.param_names)
 
 

--- a/elfi/methods/inference/bsl.py
+++ b/elfi/methods/inference/bsl.py
@@ -12,7 +12,7 @@ import scipy.stats as ss
 import elfi.client
 import elfi.visualization.visualization as vis
 from elfi.methods.bsl.pdf_methods import gaussian_syn_likelihood
-from elfi.methods.inference.parameter_inference import ParameterInference
+from elfi.methods.inference.parameter_inference import ModelBased
 from elfi.methods.results import BslSample
 from elfi.methods.utils import arr2d_to_batch, batch_to_arr2d
 from elfi.model.elfi_model import ElfiModel, ObservableMixin
@@ -22,7 +22,7 @@ from elfi.model.utils import get_summary_names
 logger = logging.getLogger(__name__)
 
 
-class BSL(ParameterInference):
+class BSL(ModelBased):
     """Bayesian Synthetic Likelihood for parameter inference.
 
     For a description of the default BSL see Price et. al. 2018.
@@ -36,37 +36,42 @@ class BSL(ParameterInference):
 
     """
 
-    def __init__(self, model, n_training_data, summary_names=None, sl_method=None,
-                 is_misspec=False, **kwargs):
+    def __init__(self, model, n_sim_round, feature_names=None, likelihood=None,
+                 **kwargs):
         """Initialize the BSL sampler.
 
         Parameters
         ----------
         model : ElfiModel
             ELFI graph used by the algorithm.
-        n_training_data : int
+        n_sim_round : int
             Number of simulations for 1 parametric approximation of the likelihood.
-        summary_names : str or list, optional
-            Summaries for the synthetic likelihood.
-        sl_method : callable, optional
+        feature_names : str or list, optional
+            Features for synthetic likelihood estimation. Defaults to all Summary nodes.
+        likelihood : callable, optional
             Synthetic likelihood estimation method. Defaults to gaussian_syn_likelihood.
-        is_misspec : bool, opt
-            Whether misspecified likelihood calculation is used.
+
         """
-        model = self._resolve_model(model)
-        self.summary_names = self._resolve_summary_names(model, summary_names)
-        output_names = model.parameter_names + self.summary_names
-        super(BSL, self).__init__(model, output_names, **kwargs)
+        feature_names = feature_names or get_summary_names(model)
+        super().__init__(model, n_sim_round, feature_names, **kwargs)
+
+        self.likelihood = likelihood or gaussian_syn_likelihood
+        self.is_misspec = isinstance(likelihood, partial) and 'adjustment' in likelihood.keywords
 
         self.random_state = np.random.RandomState(self.seed)
 
-        self.sl_method_fn = sl_method or gaussian_syn_likelihood
-        self.is_rbsl = is_misspec
+        # class attributes that will be set later:
+        self.param_names = None
+        self.prior = None
+        self.n_samples = None
+        self.sigma_proposals = None
+        self.burn_in = None
+        self.logit_transform_bound = None
 
-        self.observed = self._get_observed_summary_values()
-        self.n_training_data = self._resolve_n_training_data(n_training_data)
-        self._ssx = np.zeros((self.n_training_data, self.observed.size))
-
+    @property
+    def parameter_names(self):
+        """Return the parameters to be inferred."""
+        return self.param_names or self.model.parameter_names
 
     def sample(self, n_samples, sigma_proposals, params0=None, param_names=None,
                burn_in=0, logit_transform_bound=None, **kwargs):
@@ -108,17 +113,12 @@ class BSL(ParameterInference):
             self.logit_transform_bound = np.array(self.logit_transform_bound)
 
         # allow custom parameter order
-        self.param_names = param_names or self.parameter_names
+        self.param_names = param_names or self.model.parameter_names
         self.prior = ModelPrior(self.model, parameter_names=self.param_names)
 
-        self._init_sample(n_samples, params0)
+        self.init_sample(n_samples, params0)
 
         return self.infer(n_samples+1, **kwargs)
-
-    def set_objective(self, n_samples):
-        """Set objective for inference."""
-        self.objective['n_samples'] = n_samples
-        self.objective['n_batches'] = n_samples * int(self.n_training_data / self.batch_size)
 
     def extract_result(self):
         """Extract the result from the current state.
@@ -134,7 +134,7 @@ class BSL(ParameterInference):
         for ii, p in enumerate(self.param_names):
             samples_all[p] = np.array(self.state['params'][1:, ii])
             outputs[p] = samples_all[p][self.burn_in:]
-        if self.is_rbsl:
+        if self.is_misspec:
             outputs['gamma'] = self.state['gammas'][1:]
 
         acc_rate = self.num_accepted/(self.n_samples - self.burn_in)
@@ -148,41 +148,10 @@ class BSL(ParameterInference):
              parameter_names=self.param_names
         )
 
-    def update(self, batch, batch_index):
-        """Update the inference state with a new batch.
-
-        Parameters
-        ----------
-        batch: dict
-            dict with `self.outputs` as keys and the corresponding
-            outputs for the batch as values
-        batch_index : int
-
-        """
-        super(BSL, self).update(batch, batch_index)
-
-        self._merge_batch(batch)
-        if self._round_sim == self.n_training_data:
-            self._update_sample()
-            self._init_round()
-
-    def prepare_new_batch(self, batch_index):
-        """Prepare values for a new batch.
-
-        Parameters
-        ----------
-        batch_index: int
-
-        Returns
-        -------
-        batch: dict
-
-        """
-        batch_parameters = np.repeat(np.atleast_2d(self._params), self.batch_size, axis=0)
-        return arr2d_to_batch(batch_parameters, self.param_names)
-
-
-    def _init_sample(self, n_samples, params0):
+    def current_params(self):
+        return self._params
+    
+    def init_sample(self, n_samples, params0):
 
         # check initialisation point
         if params0 is None:
@@ -200,7 +169,7 @@ class BSL(ParameterInference):
         self._params = params0
         self._round_sim = 0
 
-        if self.is_rbsl:
+        if self.is_misspec:
             self.state['gammas'] = np.zeros((n_samples + 1, self.observed.size))
             self.rbsl_state = {}
             self.rbsl_state['gamma'] = None
@@ -209,8 +178,9 @@ class BSL(ParameterInference):
             self.rbsl_state['sample_mean'] = None
             self.rbsl_state['sample_cov'] = None
 
-    def _init_round(self):
+    def init_round(self):
 
+        self.state['n_sim_round'] = 0
         current = self.state['params'][self.state['n_samples']-1].flatten()
         cov = self.sigma_proposals
         while self.state['n_samples'] < self.n_samples + 1:
@@ -225,29 +195,28 @@ class BSL(ParameterInference):
                 n = self.state['n_samples']
                 self.state['params'][n] = self.state['params'][n - 1]
                 self.state['target'][n] = self.state['target'][n - 1]
-                if self.is_rbsl:
+                if self.is_misspec:
                     self.state['gammas'][n] = self.state['gammas'][n-1]
                 self.state['n_samples'] = n + 1
 
                 # update objective
                 self.set_objective(self.objective['n_samples'] - 1)
 
-    def _update_sample(self):
+    def process_simulated(self):
 
         n = self.state['n_samples']
 
         # 1. estimate synthetic likelihood
 
-        if self.is_rbsl:
+        if self.is_misspec:
             loglikelihood, gamma, loglikelihood_prev = \
-                self.sl_method_fn(self._ssx, self.observed, self.rbsl_state)
+                self.likelihood(self.simulated, self.observed, self.rbsl_state,
+                                random_state=self.random_state)
             self.state['gammas'][n] = gamma
             self.rbsl_state['gamma'] = gamma
             self.rbsl_state['loglikelihood'] = loglikelihood_prev
         else:
-            loglikelihood = self.sl_method_fn(self._ssx, self.observed)
-
-        self._report_sample(n, self._params, loglikelihood)
+            loglikelihood = self.likelihood(self.simulated, self.observed)
 
         # 2. update state
 
@@ -258,7 +227,7 @@ class BSL(ParameterInference):
             accept_candidate = True
         else:
             params_prev = self.state['params'][n - 1]
-            if self.is_rbsl:
+            if self.is_misspec:
                 target_prev = loglikelihood_prev + self.prior.logpdf(params_prev)
             else:
                 target_prev = self.state['target'][n - 1]
@@ -270,10 +239,10 @@ class BSL(ParameterInference):
         if accept_candidate:
             self.state['params'][n] = params_current
             self.state['target'][n] = target_current
-            if self.is_rbsl:
+            if self.is_misspec:
                 self.rbsl_state['loglikelihood'] = loglikelihood
-                self.rbsl_state['sample_mean'] = np.mean(self._ssx, axis=0)
-                self.rbsl_state['sample_cov'] = np.cov(self._ssx, rowvar=False)
+                self.rbsl_state['sample_mean'] = np.mean(self.simulated, axis=0)
+                self.rbsl_state['sample_cov'] = np.cov(self.simulated, rowvar=False)
             if n > self.burn_in:
                 self.num_accepted += 1
         else:
@@ -285,12 +254,6 @@ class BSL(ParameterInference):
 
         if hasattr(self, 'burn_in') and n == self.burn_in:
             logger.info("Burn in finished. Sampling...")
-
-    def _report_sample(self, sample_index, params, SL):
-        batch_str = "Finished round {}:\n".format(sample_index)
-        fill = 6 * ' '
-        batch_str += "{}SL: {} at {}\n".format(fill, SL, params)
-        logger.debug(batch_str)
 
     def _propagate_state(self, mean, cov=0.01, random_state=None):
         """Logic for random walk proposal. Returns the proposed parameters.
@@ -461,63 +424,4 @@ class BSL(ParameterInference):
                 logJ[i] = 0
         J = np.sum(logJ)
         return J
-
-    # batch acquisition control
-
-    def _resolve_model(self, model):
-        """Resolve ELFI model to be used."""
-        if not isinstance(model, ElfiModel):
-            raise ValueError('model must be an ElfiModel.')
-        return model
-
-    def _resolve_n_training_data(self, n_training_data):
-        """Resolve the size of training data to be used."""
-        if isinstance(n_training_data, int) and n_training_data > 0:
-            if n_training_data % self.batch_size == 0:
-                return n_training_data
-            raise ValueError('n_training_data must be a multiple of batch_size.')
-        raise TypeError('n_training_data must be a positive int.')
-
-    def _resolve_summary_names(self, model, summary_names):
-        """Resolve summary statistics to be used."""
-        if summary_names is None:
-            summary_names = get_summary_names(model)
-            if len(summary_names) == 0:
-                raise NotImplementedError('Could not resolve summary_names based on the model.')
-            logger.info('Using all summary statistics in synthetic likelihood estimation.')
-            return summary_names
-        if isinstance(summary_names, str):
-            summary_names = [summary_names]
-        if isinstance(summary_names, list):
-            if len(summary_names) == 0:
-                raise ValueError('summary_names must include at least one item.')
-            for summary_name in summary_names:
-                if summary_name not in model.nodes:
-                    raise ValueError(f'Node \'{summary_name}\' not found in the model.')
-                if not isinstance(model[summary_name], ObservableMixin):
-                    raise TypeError(f'Node \'{summary_name}\' is not observable.')
-            return summary_names
-        raise TypeError('summary_names must be a string or a list of strings.')
-
-    def _get_observed_summary_values(self):
-        """Get the observed values for summary statistics."""
-        obs_ss = [self.model[summary_name].observed for summary_name in self.summary_names]
-        return np.column_stack(obs_ss)
-
-    def _new_round(self, batch_index):
-        """Check whether batch_index starts a new data collection round."""
-        return (batch_index * self.batch_size) % self.n_training_data == 0
-
-    def _merge_batch(self, batch):
-        """Add batch to collected data."""
-        data = batch_to_arr2d(batch, self.summary_names)
-        self._ssx[self._round_sim:self._round_sim + self.batch_size] = data
-        self._round_sim += self.batch_size
-
-    def _allow_submit(self, batch_index):
-        """Check whether batch_index can be prepared."""
-        if self._new_round(batch_index) and self.batches.has_pending:
-            return False
-        else:
-            return super(BSL, self)._allow_submit(batch_index)
 

--- a/elfi/methods/inference/bsl.py
+++ b/elfi/methods/inference/bsl.py
@@ -32,8 +32,7 @@ class BSL(ModelBased):
 
     """
 
-    def __init__(self, model, n_sim_round, feature_names=None, likelihood=None,
-                 gamma_sampler=None, **kwargs):
+    def __init__(self, model, n_sim_round, feature_names=None, likelihood=None, **kwargs):
         """Initialize the BSL sampler.
 
         Parameters
@@ -120,7 +119,7 @@ class BSL(ModelBased):
             self.gamma_sampler, gamma0 = self._resolve_gamma_sampler(tau, w, max_iter)
         else:
             gamma0 = None
-       
+
         self._init_state(n_samples, params0, gamma0)
         return self.infer(n_samples, **kwargs)
 

--- a/elfi/methods/inference/parameter_inference.py
+++ b/elfi/methods/inference/parameter_inference.py
@@ -495,11 +495,12 @@ class ModelBased(ParameterInference):
         batch: dict
 
         """
-        params = np.atleast_2d(self._round_params())
+        params = np.atleast_2d(self.current_params)
         batch_params = np.repeat(params, self.batch_size, axis=0)
         return arr2d_to_batch(batch_params, self.parameter_names)
 
-    def _round_params(self):
+    @property
+    def current_params(self):
         """Return parameter values explored in the current round.
 
         Each data collection round corresponds to fixed parameter values. The values

--- a/elfi/model/elfi_model.py
+++ b/elfi/model/elfi_model.py
@@ -1210,4 +1210,3 @@ class AdaptiveDistance(Discrepancy):
 
         """
         return np.column_stack([d(u, v) for d in self.state['distance_functions']])
-

--- a/elfi/model/utils.py
+++ b/elfi/model/utils.py
@@ -2,7 +2,6 @@
 
 import numpy as np
 
-import elfi
 
 def rvs_from_distribution(*params, batch_size, distribution, size=None, random_state=None):
     """Transform the rvs method of a scipy like distribution to an operation in ELFI.
@@ -51,9 +50,3 @@ def distance_as_discrepancy(dist, *summaries, observed):
     if d.ndim == 2 and d.shape[1] == 1:
         d = d.reshape(-1)
     return d
-
-
-def get_summary_names(model):
-    """Return the names of summary nodes."""
-    return [node for node in model.nodes if isinstance(model[node], elfi.model.elfi_model.Summary)
-            and not node. startswith('_')]

--- a/elfi/model/utils.py
+++ b/elfi/model/utils.py
@@ -2,6 +2,7 @@
 
 import numpy as np
 
+import elfi
 
 def rvs_from_distribution(*params, batch_size, distribution, size=None, random_state=None):
     """Transform the rvs method of a scipy like distribution to an operation in ELFI.
@@ -50,3 +51,9 @@ def distance_as_discrepancy(dist, *summaries, observed):
     if d.ndim == 2 and d.shape[1] == 1:
         d = d.reshape(-1)
     return d
+
+
+def get_summary_names(model):
+    """Return the names of summary nodes."""
+    return [node for node in model.nodes if isinstance(model[node], elfi.model.elfi_model.Summary)
+            and not node. startswith('_')]

--- a/elfi/visualization/visualization.py
+++ b/elfi/visualization/visualization.py
@@ -419,6 +419,7 @@ def plot_discrepancy(gp, parameter_names, axes=None, **kwargs):
 
     return axes
 
+
 def plot_summaries(ssx_dict, bins=30, axes=None, **kwargs):
     """Plot the summary statistics.
 

--- a/elfi/visualization/visualization.py
+++ b/elfi/visualization/visualization.py
@@ -419,8 +419,7 @@ def plot_discrepancy(gp, parameter_names, axes=None, **kwargs):
 
     return axes
 
-
-def plot_summaries(ssx_dict, summary_names, bins=30, axes=None, **kwargs):
+def plot_summaries(ssx_dict, bins=30, axes=None, **kwargs):
     """Plot the summary statistics.
 
     Intent is to check distribution shape, particularly normality,
@@ -430,9 +429,6 @@ def plot_summaries(ssx_dict, summary_names, bins=30, axes=None, **kwargs):
     ----------
     ssx_dict : dict
         Dictionary matching summary node with simulated summaries.
-    summary_names : list
-            Names of the summary nodes in the model used for the BSL
-            parametric approximation.
     bins : int, optional
         Number of bins in histograms.
     axes : plt.Axes or arraylike of plt.Axes

--- a/tests/functional/test_consistency.py
+++ b/tests/functional/test_consistency.py
@@ -179,16 +179,14 @@ def test_bsl(ma2):
     bs = 500
     n_samples = 3
 
-    elfi.SyntheticLikelihood('bsl', *ma2['d'].parents, name='SL')
-
-    bsl_res = elfi.BSL(ma2['SL'], batch_size=bs)
+    bsl_res = elfi.BSL(ma2, bs, batch_size=bs)
     sample = bsl_res.sample(n_samples, sigma_proposals=np.eye(2))
     seed = bsl_res.seed
 
-    bsl_res = elfi.BSL(ma2['SL'], batch_size=bs)
+    bsl_res = elfi.BSL(ma2, bs, batch_size=bs)
     sample_diff = bsl_res.sample(n_samples, sigma_proposals=np.eye(2))
 
-    bsl_res = elfi.BSL(ma2['SL'], batch_size=bs, seed=seed)
+    bsl_res = elfi.BSL(ma2, bs, batch_size=bs, seed=seed)
     sample_same = bsl_res.sample(n_samples, sigma_proposals=np.eye(2))
 
     check_consistent_sample(sample, sample_diff, sample_same)

--- a/tests/functional/test_inference.py
+++ b/tests/functional/test_inference.py
@@ -916,15 +916,15 @@ def test_wbsl():
     W = estimate_whitening_matrix(tmp_m, 5000, true_params, feature_names, seed=1)
     n_sim = 100
     shrinkage = "warton"
-    penalty = select_penalty(model=tmp_m,
-                             n_sim=n_sim,
-                             theta=true_params,
-                             feature_names=feature_names,
-                             M=10,
-                             shrinkage=shrinkage,
-                             whitening=W,
-                             sigma=1.5,
-                             seed=1
-                             )
+    penalty, std_value = select_penalty(model=tmp_m,
+                                        n_sim=n_sim,
+                                        theta=true_params,
+                                        feature_names=feature_names,
+                                        M=10,
+                                        shrinkage=shrinkage,
+                                        whitening=W,
+                                        sigma=1.5,
+                                        seed=1
+                                        )
     likelihood = bsl_likelihood(whitening=W, penalty=penalty, shrinkage=shrinkage)
     check_bsl(likelihood, n_sim)


### PR DESCRIPTION
#### Summary:

aim was to remove the `SyntheticLikelihood` node and update how BSL does data collection so that we can use BSL with batch sizes smaller than the simulation count used in likelihood estimation.

since the likelihood estimation node was removed and its functionalities were moved to the BSL class, some modifications were needed in how the BSL sampler and its support methods are used. see demonstration [here](https://github.com/uremes/elfi-notebooks/blob/update_bsl/bsl.ipynb).

also since all model-based methods (BSL, BOLFIRE) share the need to collect data from simulations repeated with the same parameter values, there is now a new base class that handles the data collection in batches, and the new BSL version uses this base class.

#### Please make sure

- [x] You have updated the CHANGELOG.rst
- [x] You have provided a short summary of your changes (see previous section)
- [x] You have listed the copyright holder for the work you are submitting (see next section)

If your contribution adds, removes or somehow changes the functional behavior of the package, please check that

- [ ] You have included or updated all the relevant documentation 
- [ ] You have added appropriate unit tests to ensure the new features behave as expected

note! the [tutorial notebook](https://github.com/elfi-dev/notebooks/pull/15) that the above-linked demo notebook is based on needs to be updated, but i propose to do that when this update has been reviewed and if it looks like we want to use it.

and the proposed changes pass all unit tests (check step 6 of CONTRIBUTING.rst for details)

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD3 (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
