### PR TITLE
Remove plot summaries

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,7 @@
 Changelog
 =========
 
+- Fix plot marginals and remove plot summaries
 - Remove synthetic likelihood node and update BSL data collection
 - Fix M/G/1 example
 - Fix scratch assay example

--- a/elfi/methods/bsl/pre_sample_methods.py
+++ b/elfi/methods/bsl/pre_sample_methods.py
@@ -47,7 +47,7 @@ def plot_features(model, theta, n_sim, feature_names):
         else:
             ssx_dict[output_name] = ssx[output_name]
 
-    vis.plot_summaries(ssx_dict)
+    vis.plot_marginals(ssx_dict, ncols=int(np.ceil(np.sqrt(len(ssx_dict)))), bins=30)
 
 
 def plot_covariance_matrix(model, theta, n_sim, feature_names, corr=False,

--- a/elfi/visualization/visualization.py
+++ b/elfi/visualization/visualization.py
@@ -148,10 +148,10 @@ def plot_marginals(samples, selector=None, bins=20, axes=None,
     axes : np.array of plt.Axes
 
     """
-    ncols = len(samples.keys()) if len(samples.keys()) > 5 else 5
+    ncols = len(samples.keys()) if len(samples.keys()) < 5 else 5
     ncols = kwargs.pop('ncols', ncols)
     samples = _limit_params(samples, selector)
-    shape = (max(1, len(samples) // ncols), min(len(samples), ncols))
+    shape = (-(len(samples) // -ncols), min(len(samples), ncols))
     axes, kwargs = _create_axes(axes, shape, **kwargs)
 
     axes = axes.ravel()
@@ -171,6 +171,8 @@ def plot_marginals(samples, selector=None, bins=20, axes=None,
         else:
             axes[idx].hist(samples[key], bins=bins, **kwargs)
         axes[idx].set_xlabel(key)
+    for idx in range(len(samples), len(axes)):
+        axes[idx].set_axis_off()
     return axes
 
 

--- a/elfi/visualization/visualization.py
+++ b/elfi/visualization/visualization.py
@@ -422,44 +422,6 @@ def plot_discrepancy(gp, parameter_names, axes=None, **kwargs):
     return axes
 
 
-def plot_summaries(ssx_dict, bins=30, axes=None, **kwargs):
-    """Plot the summary statistics.
-
-    Intent is to check distribution shape, particularly normality,
-    for BSL inference.
-
-    Parameters
-    ----------
-    ssx_dict : dict
-        Dictionary matching summary node with simulated summaries.
-    bins : int, optional
-        Number of bins in histograms.
-    axes : plt.Axes or arraylike of plt.Axes
-
-    Returns
-    -------
-    axes : plt.Axes or arraylike of plt.Axes
-        Axes to plot summary statistic
-
-    """
-    n_plots_col = int(np.ceil(np.sqrt(len(ssx_dict))))
-    n_plots_row = len(ssx_dict) // n_plots_col
-    if len(ssx_dict) % n_plots_col != 0:
-        n_plots_row += 1
-
-    samples = _limit_params(ssx_dict)
-    shape = (n_plots_row, n_plots_col)
-    axes, kwargs = _create_axes(axes, shape, **kwargs)
-
-    for ii, summary in enumerate(samples):
-        row_idx = ii // n_plots_col
-        col_idx = ii % n_plots_col
-        axes[row_idx, col_idx].hist(ssx_dict[summary], bins=bins)
-        axes[row_idx, col_idx].set_xlabel(summary)
-
-    return axes
-
-
 def plot_gp(gp, parameter_names, axes=None, resol=50,
             const=None, bounds=None, true_params=None, **kwargs):
     """Plot pairwise relationships as a matrix with parameters vs. discrepancy.


### PR DESCRIPTION
#### Summary:
this update fixes the axes shape in `plot_marginals` and removes `plot_summaries`. `plot_summaries` is not needed because both visualisation methods take a sample dict as input and plot sample histograms. the main difference between the two methods was that `plot_marginals` was not able to divide plots into several rows due to the error that is fixed here.

#### Please make sure

- [x] You have updated the CHANGELOG.rst
- [x] You have provided a short summary of your changes (see previous section)
- [x] You have listed the copyright holder for the work you are submitting (see next section)

If your contribution adds, removes or somehow changes the functional behavior of the package, please check that

- [ ] You have included or updated all the relevant documentation 
- [ ] You have added appropriate unit tests to ensure the new features behave as expected

and the proposed changes pass all unit tests (check step 6 of CONTRIBUTING.rst for details)

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD3 (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
