### PR TITLE
BSL update semiparametric likelihood calculation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,7 @@
 Changelog
 =========
 
+- Fix semiparametric synthetic likelihood with glasso/warton and add tests
 - Remove synthetic likelihood node and update BSL data collection
 - Fix M/G/1 example
 - Fix scratch assay example

--- a/elfi/methods/bsl/cov_warton.py
+++ b/elfi/methods/bsl/cov_warton.py
@@ -19,7 +19,7 @@ def cov_warton(S, gamma):
 
     """
     if gamma < 0 or gamma > 1:
-        raise("Gamma must be between 0 and 1")
+        raise ValueError("Gamma must be between 0 and 1")
     _, ns = S.shape
     eps = 1e-5  # prevent divide by 0 for r_hat
     D1 = np.diag(1/np.sqrt(np.diag(S + eps)))

--- a/elfi/methods/bsl/gaussian_copula_density.py
+++ b/elfi/methods/bsl/gaussian_copula_density.py
@@ -78,16 +78,14 @@ def gaussian_copula_density(rho_hat, u, whitening=None, eta_cov=None):
     _, logdet = np.linalg.slogdet(rho)  # don't need sign, only logdet
 
     try:
-        if whitening is None:
-            mat = np.subtract(np.linalg.inv(rho), np.eye(dim))
-        else:
-            mat = np.linalg.inv(rho)
+        mat = np.linalg.inv(rho)
     except np.linalg.LinAlgError:
         logger.warning('Unable to invert rho, the estimated correlation matrix'
                        'for the simulated summaries.')
         return -math.inf
 
-    mat_res = np.dot(np.dot(np.transpose(eta), mat), eta)
-    mat_res = float(mat_res)
+    # this is the same as np.dot(np.dot(eta, np.subtract(mat, np.eye(dim))), eta) but compatible
+    # with whitened eta and mat
+    mat_res = np.dot(np.dot(np.transpose(eta), mat), eta) - np.sum(eta**2)
     res = -0.5 * (logdet + mat_res)
     return res

--- a/elfi/methods/bsl/gaussian_copula_density.py
+++ b/elfi/methods/bsl/gaussian_copula_density.py
@@ -34,8 +34,7 @@ def p2P(param, n_rows):
     return P
 
 
-def gaussian_copula_density(rho_hat, u, penalty=None, whitening=None,
-                            eta_cov=None):
+def gaussian_copula_density(rho_hat, u, whitening=None, eta_cov=None):
     """Log gaussian copula density for summary statistic likelihood.
 
     Parameters
@@ -44,8 +43,6 @@ def gaussian_copula_density(rho_hat, u, penalty=None, whitening=None,
         The estimated correlation matrix for the simulated summaries
     u : np.array
         The CDF of the observed summaries for the KDE using simulated summaries
-    penalty : float
-        The warton shrinkage penalty (used with whitening)
     whitening : np.array of shape (m x m) - m = num of summary statistics
         The whitening matrix that can be used to estimate the sample
         covariance matrix in 'BSL' or 'semiBsl' methods. Whitening
@@ -62,13 +59,11 @@ def gaussian_copula_density(rho_hat, u, penalty=None, whitening=None,
     if whitening is not None:  # logic for wsemiBsl
         eta = np.matmul(whitening, eta)
 
-        r_warton = corr_warton(rho_hat, penalty)
-
         rho_hat_sigma = np.matmul(np.matmul(whitening, eta_cov),
                                   np.transpose(whitening))
         rho_hat_sigma_diag = np.diag(np.sqrt(np.diag(rho_hat_sigma)))
         rho_hat = np.matmul(rho_hat_sigma_diag,
-                            np.matmul(r_warton, rho_hat_sigma_diag))
+                            np.matmul(rho_hat, rho_hat_sigma_diag))
 
     dim = len(u)
     eta = np.array(eta).reshape(-1, 1)

--- a/elfi/methods/bsl/gaussian_copula_density.py
+++ b/elfi/methods/bsl/gaussian_copula_density.py
@@ -6,32 +6,7 @@ import math
 import numpy as np
 from scipy.stats import norm
 
-from elfi.methods.bsl.cov_warton import corr_warton
-
 logger = logging.getLogger(__name__)
-
-
-def p2P(param, n_rows):
-    """Convert vector to symmetric matrix.
-
-    Construct a symmetric matrix with 1s on the diagonal from the given
-    parameter vector
-
-    Parameters
-    ----------
-    param : np.array
-    n_rows : int
-
-    Returns
-    -------
-    P : np.array
-
-    """
-    P = np.diag(np.zeros(n_rows))
-    P[np.triu_indices(n_rows, 1)] = param
-    P = np.add(P, np.transpose(P))
-    np.fill_diagonal(P, 1)
-    return P
 
 
 def gaussian_copula_density(rho_hat, u, whitening=None, eta_cov=None):
@@ -65,20 +40,14 @@ def gaussian_copula_density(rho_hat, u, whitening=None, eta_cov=None):
         rho_hat = np.matmul(rho_hat_sigma_diag,
                             np.matmul(rho_hat, rho_hat_sigma_diag))
 
-    dim = len(u)
     eta = np.array(eta).reshape(-1, 1)
     if any(np.isinf(eta)):
         return -math.inf
 
-    if rho_hat.ndim == 1:
-        rho = p2P(rho_hat, dim)
-    else:
-        rho = rho_hat
-
-    _, logdet = np.linalg.slogdet(rho)  # don't need sign, only logdet
+    _, logdet = np.linalg.slogdet(rho_hat)  # don't need sign, only logdet
 
     try:
-        mat = np.linalg.inv(rho)
+        mat = np.linalg.inv(rho_hat)
     except np.linalg.LinAlgError:
         logger.warning('Unable to invert rho, the estimated correlation matrix'
                        'for the simulated summaries.')

--- a/elfi/methods/bsl/gaussian_rank_corr.py
+++ b/elfi/methods/bsl/gaussian_rank_corr.py
@@ -1,20 +1,39 @@
 """Compute the gaussian rank correlation estimator."""
 
 import numpy as np
-from scipy import stats as ss
-
-from elfi.methods.bsl.gaussian_copula_density import p2P
+import scipy.stats as ss
 
 
-def gaussian_rank_corr(x, vec=False):
+def p2P(param, n_rows):
+    """Convert vector to symmetric matrix.
+
+    Construct a symmetric matrix with 1s on the diagonal from the given
+    parameter vector
+
+    Parameters
+    ----------
+    param : np.array
+    n_rows : int
+
+    Returns
+    -------
+    P : np.array
+
+    """
+    P = np.diag(np.zeros(n_rows))
+    P[np.triu_indices(n_rows, 1)] = param
+    P = np.add(P, np.transpose(P))
+    np.fill_diagonal(P, 1)
+    return P
+
+
+def gaussian_rank_corr(x):
     """Calculate the gaussian rank correlation matrix.
 
     Parameters
     ----------
     x : np.array
         Simulated summaries matrix
-    vec : bool, int
-        Whether to return in 2D or 1D format
 
     Returns
     -------
@@ -29,6 +48,5 @@ def gaussian_rank_corr(x, vec=False):
     res = [np.matmul(rqnorm[:, i], rqnorm[:, (i+1):(p+1)]) for i in range(p - 1)]
     res = np.concatenate(res).ravel()
     res = res / density
-    if not vec:
-        res_mat = p2P(res, n_rows=p)
+    res_mat = p2P(res, n_rows=p)
     return res_mat

--- a/elfi/methods/bsl/pdf_methods.py
+++ b/elfi/methods/bsl/pdf_methods.py
@@ -9,7 +9,7 @@ import scipy.stats as ss
 from scipy.special import loggamma
 from sklearn.covariance import graphical_lasso
 
-from elfi.methods.bsl.cov_warton import cov_warton, corr_warton
+from elfi.methods.bsl.cov_warton import corr_warton, cov_warton
 from elfi.methods.bsl.gaussian_copula_density import gaussian_copula_density
 from elfi.methods.bsl.gaussian_rank_corr import gaussian_rank_corr as grc
 

--- a/elfi/methods/bsl/pdf_methods.py
+++ b/elfi/methods/bsl/pdf_methods.py
@@ -227,7 +227,7 @@ def semi_param_kernel_estimate(ssx, ssy, shrinkage=None, penalty=None, whitening
 
         # NOTE: bw_method - "silverman" is being used here is slightly
         #       different than "nrd0" - silverman's rule of thumb in R.
-        kernel = ss.kde.gaussian_kde(ssx_j, bw_method="silverman")
+        kernel = ss.gaussian_kde(ssx_j, bw_method="silverman")
         logpdf_y[j] = kernel.logpdf(y)
 
         y_u[j] = kernel.integrate_box_1d(np.NINF, y)

--- a/elfi/methods/bsl/pdf_methods.py
+++ b/elfi/methods/bsl/pdf_methods.py
@@ -231,6 +231,7 @@ def semi_param_kernel_estimate(ssx, ssy, shrinkage=None, penalty=None, whitening
         logpdf_y[j] = kernel.logpdf(y)
 
         y_u[j] = kernel.integrate_box_1d(np.NINF, y)
+        y_u[j] = min(1, y_u[j])  # fix numerical errors, CDF values cannot exceed 1
 
         if whitening is not None:
             # TODO? Commented out very inefficient for large simulation count
@@ -262,9 +263,7 @@ def semi_param_kernel_estimate(ssx, ssy, shrinkage=None, penalty=None, whitening
         rho_hat = corr_warton(rho_hat, penalty)
 
     gaussian_logpdf = gaussian_copula_density(rho_hat, y_u, whitening, eta_cov)
-
     pdf = gaussian_logpdf + np.sum(logpdf_y)
-    pdf = np.nan_to_num(pdf, nan=np.NINF)
 
     return np.array([pdf])
 

--- a/elfi/methods/bsl/pdf_methods.py
+++ b/elfi/methods/bsl/pdf_methods.py
@@ -264,11 +264,6 @@ def semi_param_kernel_estimate(ssx, ssy, shrinkage=None, penalty=None, whitening
     gaussian_logpdf = gaussian_copula_density(rho_hat, y_u, whitening, eta_cov)
 
     pdf = gaussian_logpdf + np.sum(logpdf_y)
-
-    if whitening is not None:
-        Z_y = ss.norm.ppf(y_u)
-        pdf -= np.sum(ss.norm.logpdf(Z_y, 0, 1))
-
     pdf = np.nan_to_num(pdf, nan=np.NINF)
 
     return np.array([pdf])

--- a/elfi/methods/bsl/pdf_methods.py
+++ b/elfi/methods/bsl/pdf_methods.py
@@ -9,7 +9,7 @@ import scipy.stats as ss
 from scipy.special import loggamma
 from sklearn.covariance import graphical_lasso
 
-from elfi.methods.bsl.cov_warton import cov_warton
+from elfi.methods.bsl.cov_warton import cov_warton, corr_warton
 from elfi.methods.bsl.gaussian_copula_density import gaussian_copula_density
 from elfi.methods.bsl.gaussian_rank_corr import gaussian_rank_corr as grc
 
@@ -258,9 +258,10 @@ def semi_param_kernel_estimate(ssx, ssy, shrinkage=None, penalty=None, whitening
         std = np.sqrt(np.diag(sample_cov))
         rho_hat = np.outer(1/std, 1/std) * sample_cov
 
-    gaussian_logpdf = gaussian_copula_density(rho_hat, y_u,
-                                              penalty, whitening,
-                                              eta_cov)
+    if shrinkage == "warton":
+        rho_hat = corr_warton(rho_hat, penalty)
+
+    gaussian_logpdf = gaussian_copula_density(rho_hat, y_u, whitening, eta_cov)
 
     pdf = gaussian_logpdf + np.sum(logpdf_y)
 

--- a/elfi/methods/bsl/pdf_methods.py
+++ b/elfi/methods/bsl/pdf_methods.py
@@ -247,14 +247,16 @@ def semi_param_kernel_estimate(ssx, ssy, shrinkage=None, penalty=None, whitening
         rho_hat = grc(sim_eta_trans)
 
     if shrinkage == "glasso":
+        # convert from correlation matrix -> covariance
         sample_cov = np.cov(ssx, rowvar=False)
         std = np.sqrt(np.diag(sample_cov))
-        # convert from correlation matrix -> covariance
         sample_cov = np.outer(std, std) * rho_hat
-        sample_cov = np.atleast_2d(sample_cov)
+        # graphical lasso
         gl = graphical_lasso(sample_cov, alpha=penalty)
         sample_cov = gl[0]
-        rho_hat = np.corrcoef(sample_cov)
+        # convert from covariance -> correlation matrix
+        std = np.sqrt(np.diag(sample_cov))
+        rho_hat = np.outer(1/std, 1/std) * sample_cov
 
     gaussian_logpdf = gaussian_copula_density(rho_hat, y_u,
                                               penalty, whitening,

--- a/tests/functional/test_syn_likelihoods.py
+++ b/tests/functional/test_syn_likelihoods.py
@@ -1,4 +1,4 @@
-OAimport numpy as np
+import numpy as np
 import scipy.stats as ss
 
 from elfi.methods.bsl import pdf_methods
@@ -26,8 +26,9 @@ def test_gaussian_syn_likelihood_glasso():
     p_11 = pdf_methods.gaussian_syn_likelihood(ssx, test_1[0], shrinkage='glasso', penalty=0)
     assert np.isclose(p_10, p_11)
 
-    p_12 = pdf_methods.gaussian_syn_likelihood(ssx, test_1[0], shrinkage='glasso', penalty=0.2)
-    p_22 = pdf_methods.gaussian_syn_likelihood(ssx, test_2[0], shrinkage='glasso', penalty=0.2)
+    p_12 = pdf_methods.gaussian_syn_likelihood(ssx, test_1[0], shrinkage='glasso', penalty=0.1)
+    p_22 = pdf_methods.gaussian_syn_likelihood(ssx, test_2[0], shrinkage='glasso', penalty=0.1)
+    assert np.isclose(p_12, test_1[1], atol=0.1)
     assert p_12 > p_11
     assert p_12 > p_22
 
@@ -38,8 +39,9 @@ def test_gaussian_syn_likelihood_warton():
     p_11 = pdf_methods.gaussian_syn_likelihood(ssx, test_1[0], shrinkage='warton', penalty=1)
     assert np.isclose(p_10, p_11)
 
-    p_12 = pdf_methods.gaussian_syn_likelihood(ssx, test_1[0], shrinkage='warton', penalty=0.8)
-    p_22 = pdf_methods.gaussian_syn_likelihood(ssx, test_2[0], shrinkage='warton', penalty=0.8)
+    p_12 = pdf_methods.gaussian_syn_likelihood(ssx, test_1[0], shrinkage='warton', penalty=0.9)
+    p_22 = pdf_methods.gaussian_syn_likelihood(ssx, test_2[0], shrinkage='warton', penalty=0.9)
+    assert np.isclose(p_12, test_1[1], atol=0.1)
     assert p_12 > p_11
     assert p_12 > p_22
 
@@ -57,8 +59,9 @@ def test_semi_param_kernel_estimate_glasso():
     p_11 = pdf_methods.semi_param_kernel_estimate(ssx, test_1[0], shrinkage='glasso', penalty=0)
     assert np.isclose(p_10, p_11)
 
-    p_12 = pdf_methods.semi_param_kernel_estimate(ssx, test_1[0], shrinkage='glasso', penalty=0.2)
-    p_22 = pdf_methods.semi_param_kernel_estimate(ssx, test_2[0], shrinkage='glasso', penalty=0.2)
+    p_12 = pdf_methods.semi_param_kernel_estimate(ssx, test_1[0], shrinkage='glasso', penalty=0.1)
+    p_22 = pdf_methods.semi_param_kernel_estimate(ssx, test_2[0], shrinkage='glasso', penalty=0.1)
+    assert np.isclose(p_12, test_1[1], atol=0.1)
     assert p_12 > p_11
     assert p_12 > p_22
 
@@ -69,7 +72,8 @@ def test_semi_param_kernel_estimate_warton():
     p_11 = pdf_methods.semi_param_kernel_estimate(ssx, test_1[0], shrinkage='warton', penalty=1)
     assert np.isclose(p_10, p_11)
 
-    p_12 = pdf_methods.semi_param_kernel_estimate(ssx, test_1[0], shrinkage='warton', penalty=0.8)
-    p_22 = pdf_methods.semi_param_kernel_estimate(ssx, test_1[0], shrinkage='warton', penalty=0.8)
+    p_12 = pdf_methods.semi_param_kernel_estimate(ssx, test_1[0], shrinkage='warton', penalty=0.9)
+    p_22 = pdf_methods.semi_param_kernel_estimate(ssx, test_2[0], shrinkage='warton', penalty=0.9)
+    assert np.isclose(p_12, test_1[1], atol=0.1)
     assert p_12 > p_11
     assert p_12 > p_22

--- a/tests/functional/test_syn_likelihoods.py
+++ b/tests/functional/test_syn_likelihoods.py
@@ -3,77 +3,92 @@ import scipy.stats as ss
 
 from elfi.methods.bsl import pdf_methods
 
+
 def make_test_data(seed=270922):
-    mean = [0, 5]
-    cov = [[0.5, 0.2], [0.2, 0.5]]
-    x_1 = [1, 5]
-    x_2 = [2, 2]
+    mean = np.array([0, 5])
+    cov = np.array([[0.5, 0.2], [0.2, 0.5]])
+    x_1 = mean
+    x_2 = mean + 0.75
     p_1 = ss.multivariate_normal.logpdf(x_1, mean, cov)
     p_2 = ss.multivariate_normal.logpdf(x_2, mean, cov)
-    nsim = 500
+    nsim = 1000
     data = ss.multivariate_normal.rvs(mean, cov, nsim, random_state=seed)
     return data, (x_1, p_1), (x_2, p_2)
+
 
 def test_gaussian_syn_likelihood():
     ssx, test_1, test_2 = make_test_data()
     assert np.isclose(pdf_methods.gaussian_syn_likelihood(ssx, test_1[0]), test_1[1], atol=0.1)
-    assert np.isclose(pdf_methods.gaussian_syn_likelihood(ssx, test_2[0]), test_2[1], atol=0.5)
+    assert np.isclose(pdf_methods.gaussian_syn_likelihood(ssx, test_2[0]), test_2[1], atol=0.1)
+
 
 def test_gaussian_syn_likelihood_glasso():
     ssx, test_1, test_2 = make_test_data()
 
-    p_10 = pdf_methods.gaussian_syn_likelihood(ssx, test_1[0])
-    p_11 = pdf_methods.gaussian_syn_likelihood(ssx, test_1[0], shrinkage='glasso', penalty=0)
-    assert np.isclose(p_10, p_11)
+    p_0 = pdf_methods.gaussian_syn_likelihood(ssx, test_1[0])
+    p_1 = pdf_methods.gaussian_syn_likelihood(ssx, test_1[0], shrinkage='glasso', penalty=0)
+    assert np.isclose(p_0, p_1)
 
-    p_12 = pdf_methods.gaussian_syn_likelihood(ssx, test_1[0], shrinkage='glasso', penalty=0.1)
-    p_22 = pdf_methods.gaussian_syn_likelihood(ssx, test_2[0], shrinkage='glasso', penalty=0.1)
-    assert np.isclose(p_12, test_1[1], atol=0.1)
-    assert p_12 > p_11
-    assert p_12 > p_22
+    p_1 = pdf_methods.gaussian_syn_likelihood(ssx, test_1[0], shrinkage='glasso', penalty=0.2)
+    p_2 = pdf_methods.gaussian_syn_likelihood(ssx, test_2[0], shrinkage='glasso', penalty=0.2)
+    assert p_2 < p_1
+
+    p_1 = pdf_methods.gaussian_syn_likelihood(ssx, test_2[0], shrinkage='glasso', penalty=0.1)
+    p_2 = pdf_methods.gaussian_syn_likelihood(ssx, test_2[0], shrinkage='glasso', penalty=0.2)
+    assert p_2 < p_1
+
 
 def test_gaussian_syn_likelihood_warton():
     ssx, test_1, test_2 = make_test_data()
 
-    p_10 = pdf_methods.gaussian_syn_likelihood(ssx, test_1[0])
-    p_11 = pdf_methods.gaussian_syn_likelihood(ssx, test_1[0], shrinkage='warton', penalty=1)
-    assert np.isclose(p_10, p_11)
+    p_0 = pdf_methods.gaussian_syn_likelihood(ssx, test_1[0])
+    p_1 = pdf_methods.gaussian_syn_likelihood(ssx, test_1[0], shrinkage='warton', penalty=1)
+    assert np.isclose(p_0, p_1)
 
-    p_12 = pdf_methods.gaussian_syn_likelihood(ssx, test_1[0], shrinkage='warton', penalty=0.9)
-    p_22 = pdf_methods.gaussian_syn_likelihood(ssx, test_2[0], shrinkage='warton', penalty=0.9)
-    assert np.isclose(p_12, test_1[1], atol=0.1)
-    assert p_12 > p_11
-    assert p_12 > p_22
+    p_1 = pdf_methods.gaussian_syn_likelihood(ssx, test_1[0], shrinkage='warton', penalty=0.8)
+    p_2 = pdf_methods.gaussian_syn_likelihood(ssx, test_2[0], shrinkage='warton', penalty=0.8)
+    assert p_2 < p_1
+
+    p_1 = pdf_methods.gaussian_syn_likelihood(ssx, test_2[0], shrinkage='warton', penalty=0.9)
+    p_2 = pdf_methods.gaussian_syn_likelihood(ssx, test_2[0], shrinkage='warton', penalty=0.8)
+    assert p_2 < p_1
+
 
 def test_semi_param_kernel_estimate():
     ssx, test_1, test_2 = make_test_data()
     p_1 = pdf_methods.semi_param_kernel_estimate(ssx, test_1[0])
     p_2 = pdf_methods.semi_param_kernel_estimate(ssx, test_2[0])
-    assert np.isclose(p_1, test_1[1], atol=0.1)
-    assert p_1 > p_2
+    assert np.isclose(p_1, test_1[1], atol=0.2)
+    assert np.isclose(p_2, test_2[1], atol=0.2)
+
 
 def test_semi_param_kernel_estimate_glasso():
     ssx, test_1, test_2 = make_test_data()
 
-    p_10 = pdf_methods.semi_param_kernel_estimate(ssx, test_1[0])
-    p_11 = pdf_methods.semi_param_kernel_estimate(ssx, test_1[0], shrinkage='glasso', penalty=0)
-    assert np.isclose(p_10, p_11)
+    p_0 = pdf_methods.semi_param_kernel_estimate(ssx, test_1[0])
+    p_1 = pdf_methods.semi_param_kernel_estimate(ssx, test_1[0], shrinkage='glasso', penalty=0)
+    assert np.isclose(p_0, p_1)
 
-    p_12 = pdf_methods.semi_param_kernel_estimate(ssx, test_1[0], shrinkage='glasso', penalty=0.1)
-    p_22 = pdf_methods.semi_param_kernel_estimate(ssx, test_2[0], shrinkage='glasso', penalty=0.1)
-    assert np.isclose(p_12, test_1[1], atol=0.1)
-    assert p_12 > p_11
-    assert p_12 > p_22
+    p_1 = pdf_methods.semi_param_kernel_estimate(ssx, test_1[0], shrinkage='glasso', penalty=0.2)
+    p_2 = pdf_methods.semi_param_kernel_estimate(ssx, test_2[0], shrinkage='glasso', penalty=0.2)
+    assert p_2 < p_1
+
+    p_1 = pdf_methods.semi_param_kernel_estimate(ssx, test_2[0], shrinkage='glasso', penalty=0.1)
+    p_2 = pdf_methods.semi_param_kernel_estimate(ssx, test_2[0], shrinkage='glasso', penalty=0.2)
+    assert p_2 < p_1
+
 
 def test_semi_param_kernel_estimate_warton():
     ssx, test_1, test_2 = make_test_data()
-    
-    p_10 = pdf_methods.semi_param_kernel_estimate(ssx, test_1[0])
-    p_11 = pdf_methods.semi_param_kernel_estimate(ssx, test_1[0], shrinkage='warton', penalty=1)
-    assert np.isclose(p_10, p_11)
 
-    p_12 = pdf_methods.semi_param_kernel_estimate(ssx, test_1[0], shrinkage='warton', penalty=0.9)
-    p_22 = pdf_methods.semi_param_kernel_estimate(ssx, test_2[0], shrinkage='warton', penalty=0.9)
-    assert np.isclose(p_12, test_1[1], atol=0.1)
-    assert p_12 > p_11
-    assert p_12 > p_22
+    p_0 = pdf_methods.semi_param_kernel_estimate(ssx, test_1[0])
+    p_1 = pdf_methods.semi_param_kernel_estimate(ssx, test_1[0], shrinkage='warton', penalty=1)
+    assert np.isclose(p_0, p_1)
+
+    p_1 = pdf_methods.semi_param_kernel_estimate(ssx, test_1[0], shrinkage='warton', penalty=0.8)
+    p_2 = pdf_methods.semi_param_kernel_estimate(ssx, test_2[0], shrinkage='warton', penalty=0.8)
+    assert p_2 < p_1
+
+    p_1 = pdf_methods.semi_param_kernel_estimate(ssx, test_2[0], shrinkage='warton', penalty=0.9)
+    p_2 = pdf_methods.semi_param_kernel_estimate(ssx, test_2[0], shrinkage='warton', penalty=0.8)
+    assert p_2 < p_1

--- a/tests/functional/test_syn_likelihoods.py
+++ b/tests/functional/test_syn_likelihoods.py
@@ -1,0 +1,75 @@
+OAimport numpy as np
+import scipy.stats as ss
+
+from elfi.methods.bsl import pdf_methods
+
+def make_test_data(seed=270922):
+    mean = [0, 5]
+    cov = [[0.5, 0.2], [0.2, 0.5]]
+    x_1 = [1, 5]
+    x_2 = [2, 2]
+    p_1 = ss.multivariate_normal.logpdf(x_1, mean, cov)
+    p_2 = ss.multivariate_normal.logpdf(x_2, mean, cov)
+    nsim = 500
+    data = ss.multivariate_normal.rvs(mean, cov, nsim, random_state=seed)
+    return data, (x_1, p_1), (x_2, p_2)
+
+def test_gaussian_syn_likelihood():
+    ssx, test_1, test_2 = make_test_data()
+    assert np.isclose(pdf_methods.gaussian_syn_likelihood(ssx, test_1[0]), test_1[1], atol=0.1)
+    assert np.isclose(pdf_methods.gaussian_syn_likelihood(ssx, test_2[0]), test_2[1], atol=0.5)
+
+def test_gaussian_syn_likelihood_glasso():
+    ssx, test_1, test_2 = make_test_data()
+
+    p_10 = pdf_methods.gaussian_syn_likelihood(ssx, test_1[0])
+    p_11 = pdf_methods.gaussian_syn_likelihood(ssx, test_1[0], shrinkage='glasso', penalty=0)
+    assert np.isclose(p_10, p_11)
+
+    p_12 = pdf_methods.gaussian_syn_likelihood(ssx, test_1[0], shrinkage='glasso', penalty=0.2)
+    p_22 = pdf_methods.gaussian_syn_likelihood(ssx, test_2[0], shrinkage='glasso', penalty=0.2)
+    assert p_12 > p_11
+    assert p_12 > p_22
+
+def test_gaussian_syn_likelihood_warton():
+    ssx, test_1, test_2 = make_test_data()
+
+    p_10 = pdf_methods.gaussian_syn_likelihood(ssx, test_1[0])
+    p_11 = pdf_methods.gaussian_syn_likelihood(ssx, test_1[0], shrinkage='warton', penalty=1)
+    assert np.isclose(p_10, p_11)
+
+    p_12 = pdf_methods.gaussian_syn_likelihood(ssx, test_1[0], shrinkage='warton', penalty=0.8)
+    p_22 = pdf_methods.gaussian_syn_likelihood(ssx, test_2[0], shrinkage='warton', penalty=0.8)
+    assert p_12 > p_11
+    assert p_12 > p_22
+
+def test_semi_param_kernel_estimate():
+    ssx, test_1, test_2 = make_test_data()
+    p_1 = pdf_methods.semi_param_kernel_estimate(ssx, test_1[0])
+    p_2 = pdf_methods.semi_param_kernel_estimate(ssx, test_2[0])
+    assert np.isclose(p_1, test_1[1], atol=0.1)
+    assert p_1 > p_2
+
+def test_semi_param_kernel_estimate_glasso():
+    ssx, test_1, test_2 = make_test_data()
+
+    p_10 = pdf_methods.semi_param_kernel_estimate(ssx, test_1[0])
+    p_11 = pdf_methods.semi_param_kernel_estimate(ssx, test_1[0], shrinkage='glasso', penalty=0)
+    assert np.isclose(p_10, p_11)
+
+    p_12 = pdf_methods.semi_param_kernel_estimate(ssx, test_1[0], shrinkage='glasso', penalty=0.2)
+    p_22 = pdf_methods.semi_param_kernel_estimate(ssx, test_2[0], shrinkage='glasso', penalty=0.2)
+    assert p_12 > p_11
+    assert p_12 > p_22
+
+def test_semi_param_kernel_estimate_warton():
+    ssx, test_1, test_2 = make_test_data()
+    
+    p_10 = pdf_methods.semi_param_kernel_estimate(ssx, test_1[0])
+    p_11 = pdf_methods.semi_param_kernel_estimate(ssx, test_1[0], shrinkage='warton', penalty=1)
+    assert np.isclose(p_10, p_11)
+
+    p_12 = pdf_methods.semi_param_kernel_estimate(ssx, test_1[0], shrinkage='warton', penalty=0.8)
+    p_22 = pdf_methods.semi_param_kernel_estimate(ssx, test_1[0], shrinkage='warton', penalty=0.8)
+    assert p_12 > p_11
+    assert p_12 > p_22


### PR DESCRIPTION
#### Summary:
this update on `semi_param_kernel_estimate` fixes the covariance to correlation matrix conversion used when `shrinkage=glasso` and updates the likelihood calculation so that warton shrinkage is used when `shrinkage=warton`. i also added tests to capture these issues and moved some computations around to make the likelihood calculation easier for me to follow.

#### Please make sure

- [x] You have updated the CHANGELOG.rst
- [x] You have provided a short summary of your changes (see previous section)
- [x] You have listed the copyright holder for the work you are submitting (see next section)

If your contribution adds, removes or somehow changes the functional behavior of the package, please check that

- [ ] You have included or updated all the relevant documentation 
- [ ] You have added appropriate unit tests to ensure the new features behave as expected

and the proposed changes pass all unit tests (check step 6 of CONTRIBUTING.rst for details)

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD3 (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
