### PR TITLE
Drop support for py36 and add py39 and  py310

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.7, 3.8, 3.9, 3.10]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.7, 3.8, 3.9, 3.10]
+        python-version: ['3.7', '3.8', '3.9', '3.10']
 
     steps:
     - uses: actions/checkout@v2

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,7 @@
 Changelog
 =========
 
+- Drop tests for py36 and add tests for py39 and py310
 - Fix couple of minor bugs in `ar1`-model
 - Update parent class in BOLFIRE
 - Fix semiparametric synthetic likelihood with glasso/warton and add tests

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -72,16 +72,16 @@ Ready to contribute? Here's how to set up `ELFI` for local development.
 3. Make sure you have `Python 3 <https://www.python.org/>`_ and
    `Anaconda Distribution <https://www.anaconda.com/>`_ installed on your
    machine. Check your conda and Python versions. Currently supported Python versions
-   are 3.6, 3.7, 3.8::
+   are 3.7, 3.8, 3.9, 3.10::
 
    $ conda -V
    $ python -V
 
 4. Install your local copy and the development requirements into a conda
-   environment. You may need to replace "3.6" in the first line with the python
+   environment. You may need to replace "3.7" in the first line with the python
    version printed in the previous step::
 
-    $ conda create -n elfi python=3.6 numpy
+    $ conda create -n elfi python=3.7 numpy
     $ source activate elfi
     $ cd elfi
     $ make dev
@@ -136,7 +136,7 @@ Before you submit a pull request, check that it meets these guidelines:
 2. If the pull request adds functionality, the docs should be updated. Put
    your new functionality into a function with a docstring, and add the
    feature to the list in README.md.
-3. The pull request should work for Python 3.6, or later. Check
+3. The pull request should work for Python 3.7, or later. Check
    https://github.com/elfi-dev/elfi/actions/workflows/pytest.yml
    and make sure that the tests pass for all supported Python versions.
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ is preferable.
 Installation with pip
 ---------------------
 
-ELFI requires Python 3.6 or greater. You can install ELFI by typing in your terminal:
+ELFI requires Python 3.7 or greater. You can install ELFI by typing in your terminal:
 
 ```
 pip install elfi

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -3,7 +3,7 @@
 Installation
 ============
 
-ELFI requires Python 3.6 or greater (see below how to install). To install ELFI, simply
+ELFI requires Python 3.7 or greater (see below how to install). To install ELFI, simply
 type in your terminal:
 
 .. code-block:: console
@@ -18,16 +18,16 @@ process.
 .. _Python installation guide: http://docs.python-guide.org/en/latest/starting/installation/
 
 
-Installing Python 3.6
+Installing Python 3.7
 ---------------------
 
 If you are new to Python, perhaps the simplest way to install it is with Anaconda_ that
-manages different Python versions. After installing Anaconda, you can create a Python 3.6.
+manages different Python versions. After installing Anaconda, you can create a Python 3.7.
 environment with ELFI:
 
 .. code-block:: console
 
-    conda create -n elfi python=3.6 numpy
+    conda create -n elfi python=3.7 numpy
     source activate elfi
     pip install elfi
 
@@ -51,7 +51,7 @@ Resolving these may sometimes go wrong:
 * If you receive an error about missing ``numpy``, please install it first.
 * If you receive an error about `yaml.load`, install ``pyyaml``.
 * On OS X with Anaconda virtual environment say `conda install python.app` and then use `pythonw` instead of `python`.
-* Note that ELFI requires Python 3.6 or greater
+* Note that ELFI requires Python 3.7 or greater
 * In some environments ``pip`` refers to Python 2.x, and you have to use ``pip3`` to use the Python 3.x version
 * Make sure your Python installation meets the versions listed in requirements_.
 

--- a/elfi/methods/diagnostics.py
+++ b/elfi/methods/diagnostics.py
@@ -75,7 +75,7 @@ class TwoStageSelection:
         self.pool = elfi.OutputPool(simulator.name)
 
     def _combine_ss(self, list_ss, max_cardinality):
-        """Create all combinations of the initialised summary statistics up till the maximum cardinality.
+        """Create all combinations of the summary statistics up till the maximum cardinality.
 
         Parameters
         ----------

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -11,6 +11,8 @@ flake8-docstrings>=1.0.2
 isort>=4.2.5, <5.0.0
 flake8-isort>=2.0.1
 pydocstyle<5.0.0
+importlib-metadata<5.0.0
+
 
 # Documentation
 Sphinx>=1.4.8

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
     long_description=(open('docs/description.rst').read()),
     license='BSD',
     classifiers=[
-        'Programming Language :: Python :: 3.6', 'Topic :: Scientific/Engineering',
+        'Programming Language :: Python :: 3.7', 'Topic :: Scientific/Engineering',
         'Topic :: Scientific/Engineering :: Artificial Intelligence',
         'Topic :: Scientific/Engineering :: Bio-Informatics',
         'Topic :: Scientific/Engineering :: Mathematics', 'Operating System :: OS Independent',


### PR DESCRIPTION
#### Summary:
Update test matrix by dropping support for py36 and adding py39 and py310

#### Please make sure

- [x] You have updated the CHANGELOG.rst
- [x] You have provided a short summary of your changes (see previous section)
- [x] You have listed the copyright holder for the work you are submitting (see next section)

If your contribution adds, removes or somehow changes the functional behavior of the package, please check that

- [ ] You have included or updated all the relevant documentation 
- [ ] You have added appropriate unit tests to ensure the new features behave as expected

and the proposed changes pass all unit tests (check step 6 of CONTRIBUTING.rst for details)

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD3 (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
