### PR TITLE
Restrict numpy version

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,7 +1,7 @@
 Changelog
 =========
 
-
+- Restrict numpy < 1.24 until codebase has been updated
 - Update documentation-related files: docs, conf.py and requirements-dev.txt 
 - Update PULL_REQUEST_TEMPLATE.md
 - Drop tests for py36 and add tests for py39 and py310

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 dask[distributed]>=2.30.0
-numpy>=1.12.1
+numpy>=1.12.1, <1.24
 scipy>=0.19
 matplotlib>=1.1
 GPy>=1.0.9


### PR DESCRIPTION
#### Summary:
New version of numpy broke the execution. Restrict numpy < 1.24 until codebase has been updated to work with the new version.

#### Please make sure

- You have read [contribution guidelines](https://elfi.readthedocs.io/en/latest/developer/contributing.html)
- You have updated CHANGELOG.rst
- You have listed the copyright holder for the work you are submitting (see next section)

If your contribution adds, removes or somehow changes the functional behavior of the package, please check that

- You have included or updated all the relevant documentation, including docstrings
- You have added appropriate functional and unit tests to ensure the new features behave as expected
- You have run `make lint`, `make docs` and `make test`

and the proposed changes pass all unit tests (check step 6 of CONTRIBUTING.rst for details)

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD3 (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
