### PR TITLE
Release v0.8.5

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,8 @@
 Changelog
 =========
 
+0.8.5 (2023-03-07)
+------------------
 - Fix the option to continue inference in model-based inference
 - Move classifiers
 - Fix readthedocs configuration
@@ -28,7 +30,7 @@ Changelog
 - Fix multidimensional indexing in daycare example
 - Add BSL method
 
-0.8.4 (2021-06-13)
+0.8.4 (2022-06-13)
 ------------------
 - Modify Lotka-Volterra model's priors as many methods do not support discrete random variables.
 - Fix acquisition index in state plot
@@ -51,7 +53,7 @@ Changelog
 - Fix is_array in utils
 - Fix acq_noise_var-bug in acquisition.py. Influenced BOLFI.
 
-0.8.3 (2021-02-17)
+0.8.3 (2022-02-17)
 ------------------
 - Add a new inference method: BOLFIRE
 - Fix the hessian approximation, visualizations and the line search algorithm in ROMC

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-**Version 0.8.4 released!** See the [CHANGELOG](CHANGELOG.rst) and [notebooks](https://github.com/elfi-dev/notebooks).
+**Version 0.8.5 released!** See the [CHANGELOG](CHANGELOG.rst) and [notebooks](https://github.com/elfi-dev/notebooks).
 
 <img src="https://raw.githubusercontent.com/elfi-dev/elfi/dev/docs/logos/elfi_logo_text_nobg.png" width="200" />
 

--- a/elfi/__init__.py
+++ b/elfi/__init__.py
@@ -32,4 +32,4 @@ __author__ = 'ELFI authors'
 __email__ = 'elfi-support@hiit.fi'
 
 # make sure __version_ is on the last non-empty line (read by setup.py)
-__version__ = '0.8.4'
+__version__ = '0.8.5'


### PR DESCRIPTION
0.8.5 (2023-03-07)
------------------
- Fix the option to continue inference in model-based inference
- Move classifiers
- Fix readthedocs configuration
- Update penalty to shrinkage parameter conversion in synthetic likelihood calculation
- Update BSL pre sample methods
- Update BslSample
- Move ROMC tests
- Update to numpy 1.24
- Update readthedocs configuration
- Restrict numpy < 1.24 until codebase has been updated
- Update documentation-related files: docs, conf.py and requirements-dev.txt 
- Update PULL_REQUEST_TEMPLATE.md
- Drop tests for py36 and add tests for py39 and py310
- Fix couple of minor bugs in `ar1`-model
- Update parent class in BOLFIRE
- Fix semiparametric synthetic likelihood with glasso/warton and add tests
- Fix plot marginals and remove plot summaries
- Fix stochastic volatility example
- Improve batch simulations in toad example
- Remove synthetic likelihood node and update BSL data collection
- Fix M/G/1 example
- Fix scratch assay example
- Add scratch assay example
- Add GP classifier for ratio estimation
- Fix multidimensional indexing in daycare example
- Add BSL method
#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD3 (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
