### PR TITLE
Release v0.8.7

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,6 +5,12 @@
 # Required
 version: 2
 
+# Set the version of Python and other tools you might need
+build:
+   os: "ubuntu-22.04"
+   tools:
+     python: "3.10"
+
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
   configuration: docs/conf.py
@@ -19,6 +25,5 @@ formats:
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-  version: 3.8
   install:
     - requirements: docs/requirements.txt

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,9 @@
 Changelog
 =========
 
+- Pin `numpy <= 1.24.0` due to `GPy`
+- Update RTD configuration
+
 0.8.6 (2023-03-07)
 ------------------
 - Fix broken 0.8.5 by adding missing `__init__.py` to elfi/methods/bsl/

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,7 @@
 Changelog
 =========
 
+- Update available methods list
 - Pin `numpy <= 1.24.0` due to `GPy`
 - Update RTD configuration
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,8 @@
 Changelog
 =========
 
+0.8.7 (2023-09-21)
+------------------
 - Update available methods list
 - Pin `numpy <= 1.24.0` due to `GPy`
 - Update RTD configuration

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-**Version 0.8.6 released!** See the [CHANGELOG](CHANGELOG.rst) and [notebooks](https://github.com/elfi-dev/notebooks).
+**Version 0.8.7 released!** See the [CHANGELOG](CHANGELOG.rst) and [notebooks](https://github.com/elfi-dev/notebooks).
 
 <img src="https://raw.githubusercontent.com/elfi-dev/elfi/dev/docs/logos/elfi_logo_text_nobg.png" width="200" />
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Currently implemented LFI methods:
 - [Bayesian Optimization for Likelihood-Free Inference (BOLFI)](http://jmlr.csail.mit.edu/papers/v17/15-017.html)
 - [Robust Optimisation Monte Carlo (ROMC)](https://arxiv.org/abs/1904.00670)
 - [Bayesian Optimization for Likelihood-Free Inference by Ratio Estimation (BOLFIRE)](https://helda.helsinki.fi/handle/10138/305039)
+- [Bayesian Synthetic Likelihood (BSL)](https://doi.org/10.1080/10618600.2017.1302882)
 
 Other notable included algorithms and methods:
 - Bayesian Optimization
@@ -124,7 +125,7 @@ Resolving these may sometimes go wrong:
 - If you receive an error about `yaml.load`, install `pyyaml`.
 - On OS X with Anaconda virtual environment say `conda install python.app` and then use
 `pythonw` instead of `python`.
-- Note that ELFI requires Python 3.6 or greater so try `pip3 install elfi`.
+- Note that ELFI requires Python 3.7 or greater so try `pip3 install elfi`.
 - Make sure your Python installation meets the versions listed in `requirements.txt`.
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -37,7 +37,7 @@ if on_RTD:
     ]
     sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)
 
-    html_theme = 'default'
+    html_theme = 'sphinx_rtd_theme'
 
 else:
     html_theme = 'sphinx_rtd_theme'

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -27,11 +27,15 @@ Currently implemented LFI methods:
 - ABC-SMC sampler with `adaptive threshold selection`_
 - Bayesian Optimization for Likelihood-Free Inference (BOLFI_) framework
 - Robust Optimization Monte Carlo (ROMC_) framework
+- Bayesian Optimization for Likelihood-Free Inference by Ratio Estimation (BOLFIRE_)
+- Bayesian Synthetic Likelihood (BSL_)
 
 .. _adaptive distance: https://projecteuclid.org/euclid.ba/1460641065
 .. _adaptive threshold selection: https://projecteuclid.org/journals/bayesian-analysis/advance-publication/Adaptive-Approximate-Bayesian-Computation-Tolerance-Selection/10.1214/20-BA1211.full
 .. _BOLFI: http://jmlr.org/papers/v17/15-017.html
 .. _ROMC:  http://proceedings.mlr.press/v108/ikonomov20a.html
+.. _BOLFIRE: https://helda.helsinki.fi/handle/10138/305039
+.. _BSL: https://doi.org/10.1080/10618600.2017.1302882
 
 ELFI also has the following non LFI methods:
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,5 @@
 # Documentation
 pygments[plugins]
 nbsphinx
+sphinx==6.2.1
+sphinx-rtd-theme==1.2.2

--- a/elfi/__init__.py
+++ b/elfi/__init__.py
@@ -32,4 +32,4 @@ __author__ = 'ELFI authors'
 __email__ = 'elfi-support@hiit.fi'
 
 # make sure __version_ is on the last non-empty line (read by setup.py)
-__version__ = '0.8.6'
+__version__ = '0.8.7'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 dask[distributed]>=2.30.0
-numpy>=1.12.1
+numpy>=1.12.1, <= 1.24.4
 scipy>=0.19
 matplotlib>=1.1
 GPy>=1.0.9


### PR DESCRIPTION
- Update available methods list
- Pin `numpy <= 1.24.0` due to `GPy`
- Update RTD configuration