### PR TITLE
Fix surrogate model copy operation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,7 @@
 Changelog
 =========
 
+- Fix surrogate model copy operation
 - Fix typo in requirements.txt
 
 0.8.7 (2023-09-21)

--- a/elfi/methods/bo/gpy_regression.py
+++ b/elfi/methods/bo/gpy_regression.py
@@ -362,7 +362,3 @@ class GPyRegression:
             kopy.gp_params['mean_function'] = self.gp_params['mean_function'].copy()
 
         return kopy
-
-    def __copy__(self):
-        """Return a copy of current instance."""
-        return self.copy()


### PR DESCRIPTION
#### Summary:
GPyRegression class both overrides `copy.copy` with its own `copy` method and tries to use `copy.copy` inside the `copy` method so that both copy methods result in a recursion error. Removing the override resolves the error.

How to test: 

Run the BOLFI notebook and try `bolfi.target_model.copy()` and/or import the `copy` module and try `copy.copy(bolfi.target_model)`.

#### Please make sure

- You have read [contribution guidelines](https://elfi.readthedocs.io/en/latest/developer/contributing.html)
- You have updated CHANGELOG.rst
- You have listed the copyright holder for the work you are submitting (see next section)

If your contribution adds, removes or somehow changes the functional behavior of the package, please check that

- You have included or updated all the relevant documentation, including docstrings
- You have added appropriate functional and unit tests to ensure the new features behave as expected
- You have run `make lint`, `make docs` and `make test`

and the proposed changes pass all unit tests (check step 6 of CONTRIBUTING.rst for details)

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD3 (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
