### PR TITLE
Enable maxiter in bo utils minimize

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,8 @@
 Changelog
 =========
 
+- Enable using `maxiter` in `bo.utils.minimize`
+
 0.8.7 (2023-09-21)
 ------------------
 - Update available methods list

--- a/elfi/methods/bo/utils.py
+++ b/elfi/methods/bo/utils.py
@@ -97,7 +97,8 @@ def minimize(fun,
     for i in range(n_start_points):
         result = scipy.optimize.minimize(fun, start_points[i, :],
                                          method=method, jac=grad,
-                                         bounds=bounds, constraints=constraints)
+                                         bounds=bounds, constraints=constraints, 
+                                         options={'maxiter': maxiter})
         locs.append(result['x'])
         vals[i] = result['fun']
 


### PR DESCRIPTION
#### Summary:
Before `maxiter=1000` was not used at all  in `minimize`, now it's passed to `scipy.optimize.minimize`

#### Please make sure

- You have read [contribution guidelines](https://elfi.readthedocs.io/en/latest/developer/contributing.html)
- You have updated CHANGELOG.rst
- You have listed the copyright holder for the work you are submitting (see next section)

If your contribution adds, removes or somehow changes the functional behavior of the package, please check that

- You have included or updated all the relevant documentation, including docstrings
- You have added appropriate functional and unit tests to ensure the new features behave as expected
- You have run `make lint`, `make docs` and `make test`

and the proposed changes pass all unit tests (check step 6 of CONTRIBUTING.rst for details)

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

@hpesonen 

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD3 (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
