### PR TITLE
RandMaxVar update and batch acquisitions

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,7 @@
 Changelog
 =========
 
+- Improve `randmaxvar` initialisation and batch acquisitions
 - Enable using `maxiter` in `bo.utils.minimize`
 - Fix surrogate model copy operation
 - Fix typo in requirements.txt

--- a/elfi/methods/bo/acquisition.py
+++ b/elfi/methods/bo/acquisition.py
@@ -327,16 +327,20 @@ class MaxVar(AcquisitionBase):
 
     """
 
-    def __init__(self, quantile_eps=.01, *args, **opts):
+    def __init__(self, model, prior, quantile_eps=.01, **opts):
         """Initialise MaxVar.
 
         Parameters
         ----------
+        model : elfi.GPyRegression
+            Gaussian process model used to calculate the unnormalised approximate likelihood.
+        prior : scipy-like distribution
+            Prior distribution.
         quantile_eps : int, optional
             Quantile of the observed discrepancies used in setting the ABC threshold.
 
         """
-        super(MaxVar, self).__init__(*args, **opts)
+        super(MaxVar, self).__init__(model, prior=prior, **opts)
         self.name = 'max_var'
         self.label_fn = 'Variance of the Unnormalised Approximate Posterior'
         self.quantile_eps = quantile_eps
@@ -492,13 +496,16 @@ class RandMaxVar(MaxVar):
 
     """
 
-    def __init__(self, quantile_eps=.01, sampler='nuts', n_samples=50, warmup=None,
-                 limit_faulty_init=1000, init_from_prior=False, sigma_proposals=None,
-                 *args, **opts):
+    def __init__(self, model, prior, quantile_eps=.01, sampler='nuts', n_samples=50, warmup=None,
+                 limit_faulty_init=1000, init_from_prior=False, sigma_proposals=None, **opts):
         """Initialise RandMaxVar.
 
         Parameters
         ----------
+        model : elfi.GPyRegression
+            Gaussian process model used to calculate the unnormalised approximate likelihood.
+        prior : scipy-like distribution
+            Prior distribution.
         quantile_eps : int, optional
             Quantile of the observed discrepancies used in setting the ABC threshold.
         sampler : string, optional
@@ -517,7 +524,7 @@ class RandMaxVar(MaxVar):
             Markov Chain sampler. Defaults to 1/10 of surrogate model bound lengths.
 
         """
-        super(RandMaxVar, self).__init__(quantile_eps, *args, **opts)
+        super(RandMaxVar, self).__init__(model, prior, quantile_eps, **opts)
         self.name = 'rand_max_var'
         self.name_sampler = sampler
         self._n_samples = n_samples
@@ -648,13 +655,17 @@ class ExpIntVar(MaxVar):
 
     """
 
-    def __init__(self, quantile_eps=.01, integration='grid', d_grid=.2,
+    def __init__(self, model, prior, quantile_eps=.01, integration='grid', d_grid=.2,
                  n_samples_imp=100, iter_imp=2, sampler='nuts', n_samples=2000,
-                 sigma_proposals=None, *args, **opts):
+                 sigma_proposals=None, **opts):
         """Initialise ExpIntVar.
 
         Parameters
         ----------
+        model : elfi.GPyRegression
+            Gaussian process model used to calculate the approximate unnormalised likelihood.
+        prior : scipy-like distribution
+            Prior distribution.
         quantile_eps : int, optional
             Quantile of the observed discrepancies used in setting the discrepancy threshold.
         integration : str, optional
@@ -680,7 +691,7 @@ class ExpIntVar(MaxVar):
             Markov Chain sampler. Defaults to 1/10 of surrogate model bound lengths.
 
         """
-        super(ExpIntVar, self).__init__(quantile_eps, *args, **opts)
+        super(ExpIntVar, self).__init__(model, prior, quantile_eps, **opts)
         self.name = 'exp_int_var'
         self.label_fn = 'Expected Loss'
         self._integration = integration

--- a/elfi/methods/bo/utils.py
+++ b/elfi/methods/bo/utils.py
@@ -97,7 +97,7 @@ def minimize(fun,
     for i in range(n_start_points):
         result = scipy.optimize.minimize(fun, start_points[i, :],
                                          method=method, jac=grad,
-                                         bounds=bounds, constraints=constraints, 
+                                         bounds=bounds, constraints=constraints,
                                          options={'maxiter': maxiter})
         locs.append(result['x'])
         vals[i] = result['fun']


### PR DESCRIPTION
#### Summary:
The randmaxvar acquisitions are sampled from the maxvar acquisition function with an MCMC sampler. Two updates are proposed here:

1. add option to use prior distribution in sampler initialisation 

The acquisition method needs to initialise the MCMC sampler with a point that has maxvar acquisition score (approximate posterior variance) above zero. The current version samples candidate points from a uniform distribution within BOLFI bounds. The updated version includes an option to sample from the prior distribution.

2. batch acquisitions

The current implementation runs one MCMC chain and returns the `batch_size` last samples. This works when `batch_size=1` but does not provide a representative sample from the maxvar acquisition function otherwise. The version proposed in this update returns the last mcmc sample when `batch_size=1` and a random sample from the MCMC chain otherwise.

For illustration, here are batches acquired by running BOLFI on the MA2 example with log-discrepancies using `batch_size=10` and the current randmaxvar implementation with `sampler=’metropolis’` and `n_samples=2000`. The batches tend to include 2-4 unique parameter values:

![image](https://github.com/elfi-dev/elfi/assets/6198446/fac9536c-dd00-47b9-8f52-3a95f6190ad6)

These are batches acquired by running the same example using the updated implementation with the same parameters as above and `warmup=500`. Most batches now include 10 unique parameter values:

![image](https://github.com/elfi-dev/elfi/assets/6198446/5027db20-1e3d-4a57-bceb-a7e0570ea8ec)

#### Please make sure

- You have read [contribution guidelines](https://elfi.readthedocs.io/en/latest/developer/contributing.html)
- You have updated CHANGELOG.rst
- You have listed the copyright holder for the work you are submitting (see next section)

If your contribution adds, removes or somehow changes the functional behavior of the package, please check that

- You have included or updated all the relevant documentation, including docstrings
- You have added appropriate functional and unit tests to ensure the new features behave as expected
- You have run `make lint`, `make docs` and `make test`

and the proposed changes pass all unit tests (check step 6 of CONTRIBUTING.rst for details)

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD3 (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
