### PR TITLE
Update acquisition cost implementation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,7 @@
 Changelog
 =========
 
+- Add option to use additive or multiplicative adjustment in any acquisition method
 - Add convenience method for obtaining elfi samples as `InferenceData`` to be used with `arviz`
 - Improve `randmaxvar` batch acquisitions and initialisation by enabling sampling from prior
 - Drop official Python support for 3.7 and 3.8 as GPy is not officially supported for these versions

--- a/elfi/methods/bo/acquisition.py
+++ b/elfi/methods/bo/acquisition.py
@@ -7,7 +7,7 @@ import scipy.linalg as sl
 import scipy.stats as ss
 
 import elfi.methods.mcmc as mcmc
-from elfi.methods.bo.utils import CostFunction, minimize
+from elfi.methods.bo.utils import minimize
 from elfi.methods.utils import resolve_sigmas
 
 logger = logging.getLogger(__name__)
@@ -223,7 +223,7 @@ class LCBSC(AcquisitionBase):
 
     """
 
-    def __init__(self, *args, delta=None, additive_cost=None, **kwargs):
+    def __init__(self, *args, delta=None, **kwargs):
         """Initialize LCBSC.
 
         Parameters
@@ -231,8 +231,6 @@ class LCBSC(AcquisitionBase):
         delta: float, optional
             In between (0, 1). Default is 1/exploration_rate. If given, overrides the
             exploration_rate.
-        additive_cost: CostFunction, optional
-            Cost function output is added to the base acquisition value.
 
         """
         if delta is not None:
@@ -243,10 +241,6 @@ class LCBSC(AcquisitionBase):
         super(LCBSC, self).__init__(*args, **kwargs)
         self.name = 'lcbsc'
         self.label_fn = 'Confidence Bound'
-
-        if additive_cost is not None and not isinstance(additive_cost, CostFunction):
-            raise TypeError("Additive cost must be type CostFunction.")
-        self.additive_cost = additive_cost
 
     @property
     def delta(self):
@@ -275,8 +269,6 @@ class LCBSC(AcquisitionBase):
         """
         mean, var = self.model.predict(x, noiseless=True)
         value = mean - np.sqrt(self._beta(t) * var)
-        if self.additive_cost is not None:
-            value += self.additive_cost.evaluate(x)
         return value
 
     def evaluate_gradient(self, x, t=None):
@@ -296,8 +288,6 @@ class LCBSC(AcquisitionBase):
         mean, var = self.model.predict(x, noiseless=True)
         grad_mean, grad_var = self.model.predictive_gradients(x)
         value = grad_mean - 0.5 * grad_var * np.sqrt(self._beta(t) / var)
-        if self.additive_cost is not None:
-            value += self.additive_cost.evaluate_gradient(x)
         return value
 
 

--- a/elfi/methods/bo/utils.py
+++ b/elfi/methods/bo/utils.py
@@ -176,7 +176,7 @@ def make_additive_acq(acquisition_class, function):
 
     Returns
     -------
-    AdditiveAcquisition
+    Type[AdditiveAcquisition]
 
     """
     class AdditiveAcquisition(acquisition_class):
@@ -208,7 +208,7 @@ def make_multiplicative_acq(acquisition_class, function):
 
     Returns
     -------
-    MultiplicativeAcquisition
+    Type[MultiplicativeAcquisition]
 
     """
     class MultiplicativeAcquisition(acquisition_class):

--- a/elfi/methods/bo/utils.py
+++ b/elfi/methods/bo/utils.py
@@ -111,20 +111,20 @@ def minimize(fun,
     return locs[ind_min], vals[ind_min]
 
 
-class CostFunction:
-    """Convenience class for modelling acquisition costs."""
+class AdjustmentFunction:
+    """Convenience class for modelling acquisition function adjustments."""
 
     def __init__(self, function, gradient, scale=1):
-        """Initialise CostFunction.
+        """Initialise AdjustmentFunction.
 
         Parameters
         ----------
         function : callable
-            Function that returns cost function value.
+            Function that returns adjustment function value.
         gradient : callable
-            Function that returns cost function gradient.
+            Function that returns adjustment function gradient.
         scale : float, optional
-            Cost function is multiplied with scale.
+            Adjustment function is multiplied with scale.
 
         """
         self.function = function
@@ -132,7 +132,7 @@ class CostFunction:
         self.scale = scale
 
     def evaluate(self, x):
-        """Return cost function value evaluated at x.
+        """Return adjustment function value evaluated at x.
 
         Parameters
         ----------
@@ -148,7 +148,7 @@ class CostFunction:
         return self.scale * self.function(x).reshape(n, 1)
 
     def evaluate_gradient(self, x):
-        """Return cost function gradient evaluated at x.
+        """Return adjustment function gradient evaluated at x.
 
         Parameters
         ----------
@@ -162,3 +162,67 @@ class CostFunction:
         x = np.atleast_2d(x)
         n, input_dim = x.shape
         return self.scale * self.gradient(x).reshape(n, input_dim)
+
+
+def make_additive_acq(acquisition_class, function):
+    """Make acquisition function adjusted with an additive term.
+
+    Parameters
+    ----------
+    acquisition_class : elfi.methods.bo.acquisition.AcquisitionBase
+        Acquisition function to be adjusted.
+    function : AdjustmentFunction
+        Function added to the base acquisition function.
+
+    Returns
+    -------
+    AdditiveAcquisition
+
+    """
+    class AdditiveAcquisition(acquisition_class):
+
+        def __init__(self, model, **kwargs):
+            super().__init__(model=model, **kwargs)
+            self._func = function
+
+        def evaluate(self, theta_new, t=None):
+            return super().evaluate(theta_new, t=t) + self._func.evaluate(theta_new)
+
+        def evaluate_gradient(self, theta_new, t=None):
+            t1 = super().evaluate_gradient(theta_new, t=t)
+            t2 = self._func.evaluate_gradient(theta_new)
+            return t1 + t2
+
+    return AdditiveAcquisition
+
+
+def make_multiplicative_acq(acquisition_class, function):
+    """Make acquisition function adjusted with a multiplictive term.
+
+    Parameters
+    ----------
+    acquisition_class : elfi.methods.bo.acquisition.AcquisitionBase
+        Acquisition function to be adjusted.
+    function : AdjustmentFunction
+        Function that multiplies the base acquisition function.
+
+    Returns
+    -------
+    MultiplicativeAcquisition
+
+    """
+    class MultiplicativeAcquisition(acquisition_class):
+
+        def __init__(self, model, **kwargs):
+            super().__init__(model=model, **kwargs)
+            self._func = function
+
+        def evaluate(self, theta_new, t=None):
+            return super().evaluate(theta_new, t=t) * self._func.evaluate(theta_new)
+
+        def evaluate_gradient(self, theta_new, t=None):
+            t1 = super().evaluate_gradient(theta_new, t=t) * self._func.evaluate(theta_new)
+            t2 = super().evaluate(theta_new, t=t) * self._func.evaluate_gradient(theta_new)
+            return t1 + t2
+
+    return MultiplicativeAcquisition

--- a/elfi/methods/bo/utils.py
+++ b/elfi/methods/bo/utils.py
@@ -176,10 +176,10 @@ def make_additive_acq(acquisition_class, function):
 
     Returns
     -------
-    Type[AdditiveAcquisition]
+    Type[AdjustedAcquisition]
 
     """
-    class AdditiveAcquisition(acquisition_class):
+    class AdjustedAcquisition(acquisition_class):
 
         def __init__(self, model, **kwargs):
             super().__init__(model=model, **kwargs)
@@ -193,7 +193,7 @@ def make_additive_acq(acquisition_class, function):
             t2 = self._func.evaluate_gradient(theta_new)
             return t1 + t2
 
-    return AdditiveAcquisition
+    return AdjustedAcquisition
 
 
 def make_multiplicative_acq(acquisition_class, function):
@@ -208,10 +208,10 @@ def make_multiplicative_acq(acquisition_class, function):
 
     Returns
     -------
-    Type[MultiplicativeAcquisition]
+    Type[AdjustedAcquisition]
 
     """
-    class MultiplicativeAcquisition(acquisition_class):
+    class AdjustedAcquisition(acquisition_class):
 
         def __init__(self, model, **kwargs):
             super().__init__(model=model, **kwargs)
@@ -225,4 +225,4 @@ def make_multiplicative_acq(acquisition_class, function):
             t2 = super().evaluate(theta_new, t=t) * self._func.evaluate_gradient(theta_new)
             return t1 + t2
 
-    return MultiplicativeAcquisition
+    return AdjustedAcquisition

--- a/elfi/methods/bo/utils.py
+++ b/elfi/methods/bo/utils.py
@@ -169,7 +169,7 @@ def make_additive_acq(acquisition_class, function):
 
     Parameters
     ----------
-    acquisition_class : elfi.methods.bo.acquisition.AcquisitionBase
+    acquisition_class : Type[elfi.methods.bo.acquisition.AcquisitionBase]
         Acquisition function to be adjusted.
     function : AdjustmentFunction
         Function added to the base acquisition function.
@@ -201,7 +201,7 @@ def make_multiplicative_acq(acquisition_class, function):
 
     Parameters
     ----------
-    acquisition_class : elfi.methods.bo.acquisition.AcquisitionBase
+    acquisition_class : Type[elfi.methods.bo.acquisition.AcquisitionBase]
         Acquisition function to be adjusted.
     function : AdjustmentFunction
         Function that multiplies the base acquisition function.

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -6,7 +6,7 @@ import scipy.stats as ss
 
 import elfi
 from elfi.examples.ma2 import get_model
-from elfi.methods.bo.utils import CostFunction, minimize, stochastic_optimization
+from elfi.methods.bo.utils import AdjustmentFunction, minimize, stochastic_optimization
 from elfi.methods.density_ratio_estimation import DensityRatioEstimation
 from elfi.methods.utils import (GMDistribution, normalize_weights, numgrad, numpy_to_python_type,
                                 sample_object_to_dict, weighted_sample_quantile, weighted_var)
@@ -283,20 +283,20 @@ class TestDensityRatioEstimation:
         assert np.max(np.abs(test_w - test_w_estim)) < 0.1
         assert np.abs(np.max(test_w) - densratio.max_ratio()) < 0.1
 
-class TestCostFunction:
 
+class TestAdjustmentFunction:
     def test_evaluate(self):
         def fun(x):
             return x[0]**2 + (x[1] - 1)**4
         
-        cost = CostFunction(elfi.tools.vectorize(fun), None, scale=10)
+        adjustment = AdjustmentFunction(elfi.tools.vectorize(fun), None, scale=10)
         x = np.array([0.5, 0.5])
-        assert np.isclose(10 * fun(x), cost.evaluate(x))
+        assert np.isclose(10 * fun(x), adjustment.evaluate(x))
 
     def test_evaluate_gradient(self):
         def grad(x):
             return np.array([2 * x[0], 4 * (x[1] - 1)**3])
 
-        cost = CostFunction(None, elfi.tools.vectorize(grad), scale=10)
+        adjustment = AdjustmentFunction(None, elfi.tools.vectorize(grad), scale=10)
         x = np.array([0.5, 0.5])
-        assert np.allclose(10 * grad(x), cost.evaluate_gradient(x))
+        assert np.allclose(10 * grad(x), adjustment.evaluate_gradient(x))

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -6,7 +6,8 @@ import scipy.stats as ss
 
 import elfi
 from elfi.examples.ma2 import get_model
-from elfi.methods.bo.utils import AdjustmentFunction, minimize, stochastic_optimization
+from elfi.methods.bo.utils import (AdjustmentFunction, minimize, stochastic_optimization,
+                                   make_additive_acq, make_multiplicative_acq)
 from elfi.methods.density_ratio_estimation import DensityRatioEstimation
 from elfi.methods.utils import (GMDistribution, normalize_weights, numgrad, numpy_to_python_type,
                                 sample_object_to_dict, weighted_sample_quantile, weighted_var)
@@ -300,3 +301,82 @@ class TestAdjustmentFunction:
         adjustment = AdjustmentFunction(None, elfi.tools.vectorize(grad), scale=10)
         x = np.array([0.5, 0.5])
         assert np.allclose(10 * grad(x), adjustment.evaluate_gradient(x))
+
+
+class TestAdjustedAcquisition:
+    class CustomAcquisition(elfi.methods.bo.acquisition.AcquisitionBase):
+        def __init__(self, model, scale=1):
+            self.model = model
+            self.scale = scale
+
+        def evaluate(self, x, t=None):
+            return self.scale * x * np.sin(x)
+
+        def evaluate_gradient(self, x, t=None):
+            return self.scale * (np.sin(x) + x * np.cos(x))
+
+        def minimize(self):
+            return minimize(self.evaluate, ((0, 10), ), grad=self.evaluate_gradient)
+
+    def get_adjustment(self, scale):
+        def func(x):
+            return scale * x
+
+        def grad(x):
+            return scale * np.ones_like(x)
+
+        return AdjustmentFunction(func, grad)
+
+    def test_evaluate_additive(self):
+        acq = self.CustomAcquisition(None, scale=-1)
+        adj = self.get_adjustment(0.5)
+        adjusted_acq = make_additive_acq(self.CustomAcquisition, adj)(None, scale=-1)
+        x = np.arange(10).reshape(10, 1)
+        y = acq.evaluate(x) + adj.evaluate(x)
+        test_y = adjusted_acq.evaluate(x)
+        assert np.allclose(test_y, y)
+
+    def test_evaluate_gradient_additive(self):
+        acq = self.CustomAcquisition(None, scale=-1)
+        adj = self.get_adjustment(0.5)
+        adjusted_acq = make_additive_acq(self.CustomAcquisition, adj)(None, scale=-1)
+        x = np.arange(10).reshape(10, 1)
+        y = acq.evaluate_gradient(x) + adj.evaluate_gradient(x)
+        test_y = adjusted_acq.evaluate_gradient(x)
+        assert np.allclose(test_y, y)
+
+    def test_minimize_additive(self):
+        acq = self.CustomAcquisition(None, scale=-1)
+        loc1, val1 = acq.minimize()
+        adj = self.get_adjustment(0.5)
+        adjusted_acq = make_additive_acq(self.CustomAcquisition, adj)(None, scale=-1)
+        loc2, val2 = adjusted_acq.minimize()
+        assert loc1 > loc2
+        assert val1 < val2
+
+    def test_evaluate_multiplicative(self):
+        acq = self.CustomAcquisition(None, scale=-1)
+        adj = self.get_adjustment(0.1)
+        adjusted_acq = make_multiplicative_acq(self.CustomAcquisition, adj)(None, scale=-1)
+        x = np.arange(10).reshape(10, 1)
+        y = acq.evaluate(x) * adj.evaluate(x)
+        test_y = adjusted_acq.evaluate(x)
+        assert np.allclose(test_y, y)
+
+    def test_evaluate_gradient_multiplicative(self):
+        acq = self.CustomAcquisition(None, scale=-1)
+        adj = self.get_adjustment(0.1)
+        adjusted_acq = make_multiplicative_acq(self.CustomAcquisition, adj)(None, scale=-1)
+        x = np.arange(10).reshape(10, 1)
+        y = acq.evaluate(x) * adj.evaluate_gradient(x) + acq.evaluate_gradient(x) * adj.evaluate(x)
+        test_y = adjusted_acq.evaluate_gradient(x)
+        assert np.allclose(test_y, y)
+
+    def test_minimize_multiplicative(self):
+        acq = self.CustomAcquisition(None, scale=-1)
+        loc1, val1 = acq.minimize()
+        adj = self.get_adjustment(0.1)
+        adjusted_acq = make_multiplicative_acq(self.CustomAcquisition, adj)(None, scale=-1)
+        loc2, val2 = adjusted_acq.minimize()
+        assert loc1 < loc2
+        assert val1 < val2


### PR DESCRIPTION
#### Summary:
This update removes `additive_cost` from the LCBSC acquisition function and adds an option to extend any acquisition function with an additive or multiplicative term.

Motivation: LCBSC was extended with an option to use `additive_cost` so that BOLFIRE could model the log-likelihood ratio but calculate acquisition scores based on the estimated log-likelihood ratio + log-prior. This modification made sense at the time since the option was not needed in other acquisition functions. However additive or multiplicative costs could also be used to take into account other information like variable simulation costs or unknown constraints. For example, when we consider robustness to failed simulations, one approach is to scale acquisition values with predicted success probabilities. For this reason, it would be nice to have the option available in all acquisition functions. 

We could update all acquisition functions to accept and use `additive_cost` and `multiplicative_cost`, but I was worried that this would only clutter the acquisition functions when it's not clear know how much use this option will have. Hence this idea that would allow either additive or multiplicative cost (*) to be combined with any acquisition function without modifications in the acquisition function. Let me know what you think!

(*) renamed to adjustment since our current and planned examples (log-prior and success probabilities) are not really costs

#### Please make sure

- You have read [contribution guidelines](https://elfi.readthedocs.io/en/latest/developer/contributing.html)
- You have updated CHANGELOG.rst
- You have listed the copyright holder for the work you are submitting (see next section)

If your contribution adds, removes or somehow changes the functional behavior of the package, please check that

- You have included or updated all the relevant documentation, including docstrings
- You have added appropriate functional and unit tests to ensure the new features behave as expected
- You have run `make lint`, `make docs` and `make test`

and the proposed changes pass all unit tests (check step 6 of CONTRIBUTING.rst for details)

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD3 (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
