### PR TITLE
Fix rtd build

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,7 @@
 Changelog
 =========
 
+- Add `arziv`-mocking to rtd-setup
 - Add convenience method for obtaining elfi samples as `InferenceData`` to be used with `arviz`
 - Improve `randmaxvar` batch acquisitions and initialisation by enabling sampling from prior
 - Drop official Python support for 3.7 and 3.8 as GPy is not officially supported for these versions

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -33,7 +33,7 @@ if on_RTD:
         'scipy.sparse', 'scipy.special', 'matplotlib.pyplot', 'numpy.random', 'networkx',
         'ipyparallel', 'numpy.lib', 'numpy.lib.format', 'sklearn.linear_model',
         'sklearn.pipeline', 'sklearn.preprocessing', 'numdifftools', 'GPy.kern', 'GPy.models',
-        'sklearn.covariance', 'sklearn.exceptions'
+        'sklearn.covariance', 'sklearn.exceptions', 'arviz'
     ]
     sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)
 


### PR DESCRIPTION
#### Summary:
Read the docs build was failing due to lack of arviz-mocking. PR fixes this.  

#### Please make sure

- You have read [contribution guidelines](https://elfi.readthedocs.io/en/latest/developer/contributing.html)
- You have updated CHANGELOG.rst
- You have listed the copyright holder for the work you are submitting (see next section)

If your contribution adds, removes or somehow changes the functional behavior of the package, please check that

- You have included or updated all the relevant documentation, including docstrings
- You have added appropriate functional and unit tests to ensure the new features behave as expected
- You have run `make lint`, `make docs` and `make test`

and the proposed changes pass all unit tests (check step 6 of CONTRIBUTING.rst for details)

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD3 (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
