### PR TITLE
Fix BOLFI parallelisation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,7 @@
 Changelog
 =========
 
+- Use kernel copy to avoid pickle issue and allow BOLFI parallelisation with non-default kernel
 - Add option to use additive or multiplicative adjustment in any acquisition method
 - Add `arziv`-mocking to rtd-setup
 - Add convenience method for obtaining elfi samples as `InferenceData`` to be used with `arviz`

--- a/elfi/methods/bo/gpy_regression.py
+++ b/elfi/methods/bo/gpy_regression.py
@@ -250,7 +250,7 @@ class GPyRegression:
                 self._kernel_is_default = True
 
         else:
-            kernel = self.gp_params.get('kernel')
+            kernel = self.gp_params.get('kernel').copy()
 
         noise_var = self.gp_params.get('noise_var') or np.max(y)**2. / 100.
         mean_function = self.gp_params.get('mean_function')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 dask[distributed]>=2.30.0
 numpy>=1.12.1
 scipy>=0.19
-matplotlib>=1.1
+matplotlib>=1.1,<3.9
 GPy>=1.0.9
 networkX>=2.0
 ipyparallel>=6


### PR DESCRIPTION
#### Summary:

copy kernel from gpy regression model `gp_params` to avoid the pickle issue reported [here](https://github.com/SheffieldML/GPy/issues/605) and allow BOLFI parallelisation also when a non-default kernel is used. fixes #263 

#### How to test: 

the pickle error is observed when we sample from a `target_model` that has a kernel in `gp_params` and either `ipyparallel` or `multiprocessing` client is used. for example the example code provided in #263 results in an error with the current ELFI version but works with the updated version.

#### Please make sure

- You have read [contribution guidelines](https://elfi.readthedocs.io/en/latest/developer/contributing.html)
- You have updated CHANGELOG.rst
- You have listed the copyright holder for the work you are submitting (see next section)

If your contribution adds, removes or somehow changes the functional behavior of the package, please check that

- You have included or updated all the relevant documentation, including docstrings
- You have added appropriate functional and unit tests to ensure the new features behave as expected
- You have run `make lint`, `make docs` and `make test`

and the proposed changes pass all unit tests (check step 6 of CONTRIBUTING.rst for details)

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD3 (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
