### PR TITLE
Fix matplotlib version

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,7 @@
 Changelog
 =========
 
+- Restrict matplotlib version < 3.9 for compatibility with GPy
 - Add option to use additive or multiplicative adjustment in any acquisition method
 - Add `arziv`-mocking to rtd-setup
 - Add convenience method for obtaining elfi samples as `InferenceData`` to be used with `arviz`

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 dask[distributed]>=2.30.0
 numpy>=1.12.1
 scipy>=0.19
-matplotlib>=1.1
+matplotlib>=1.1,<3.9
 GPy>=1.0.9
 networkX>=2.0
 ipyparallel>=6


### PR DESCRIPTION
#### Summary:

restrict matplotlib version to < 3.9 because GPy uses`matplotlib.cm.get_cmap` which is removed in 3.9.0.

#### Please make sure

- You have read [contribution guidelines](https://elfi.readthedocs.io/en/latest/developer/contributing.html)
- You have updated CHANGELOG.rst
- You have listed the copyright holder for the work you are submitting (see next section)

If your contribution adds, removes or somehow changes the functional behavior of the package, please check that

- You have included or updated all the relevant documentation, including docstrings
- You have added appropriate functional and unit tests to ensure the new features behave as expected
- You have run `make lint`, `make docs` and `make test`

and the proposed changes pass all unit tests (check step 6 of CONTRIBUTING.rst for details)

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD3 (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
