### PR TITLE
Fix target model initialisation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,7 @@
 Changelog
 =========
 
+- Update surrogate model initialisation to use all initial evidence
 - Use kernel copy to avoid pickle issue and allow BOLFI parallelisation with non-default kernel
 - Restrict matplotlib version < 3.9 for compatibility with GPy
 - Add option to use additive or multiplicative adjustment in any acquisition method

--- a/elfi/methods/inference/bolfi.py
+++ b/elfi/methods/inference/bolfi.py
@@ -95,7 +95,7 @@ class BayesianOptimization(ParameterInference):
         if precomputed is not None:
             params = batch_to_arr2d(precomputed, self.target_model.parameter_names)
             n_precomputed = len(params)
-            self.target_model.update(params, precomputed[target_name])
+            self.target_model.update(params, precomputed[target_name], optimize=True)
 
         self.batches_per_acquisition = batches_per_acquisition or self.max_parallel_batches
 
@@ -114,6 +114,10 @@ class BayesianOptimization(ParameterInference):
         self.state['n_evidence'] = self.n_precomputed_evidence
         self.state['last_GP_update'] = self.n_initial_evidence
         self.state['acquisition'] = []
+
+        if self.target_model.n_evidence < 1 and self.n_initial_evidence > 0:
+            self.init_x = np.zeros((self.n_initial_evidence, self.target_model.input_dim))
+            self.init_y = np.zeros((self.n_initial_evidence, 1))
 
     def _resolve_initial_evidence(self, initial_evidence):
         # Some sensibility limit for starting GP regression
@@ -215,10 +219,20 @@ class BayesianOptimization(ParameterInference):
         params = batch_to_arr2d(batch, self.target_model.parameter_names)
         self._report_batch(batch_index, params, batch[self.target_name])
 
-        optimize = self._should_optimize()
-        self.target_model.update(params, batch[self.target_name], optimize)
-        if optimize:
-            self.state['last_GP_update'] = self.target_model.n_evidence
+        if self.target_model.n_evidence < 1 and self.n_initial_evidence > 0:
+            # accumulate initialisation data
+            n = self.state['n_evidence']
+            self.init_x[n - self.batch_size:n] = params
+            self.init_y[n - self.batch_size:n] = batch[self.target_name].reshape(-1, 1)
+            if self.state['n_evidence'] >= self.n_initial_evidence:
+                # initialise model
+                self.target_model.update(self.init_x, self.init_y, optimize=True)
+        else:
+            # update model
+            optimize = self._should_optimize()
+            self.target_model.update(params, batch[self.target_name], optimize)
+            if optimize:
+                self.state['last_GP_update'] = self.state['n_evidence']
 
     def prepare_new_batch(self, batch_index):
         """Prepare values for a new batch.

--- a/elfi/methods/inference/bolfire.py
+++ b/elfi/methods/inference/bolfire.py
@@ -95,6 +95,8 @@ class BOLFIRE(ModelBased):
         # Initialize BO
         self.n_initial_evidence = self._resolve_n_initial_evidence(n_initial_evidence)
         self.acquisition_method = self._resolve_acquisition_method(acquisition_method)
+        self.init_x = np.zeros((self.n_initial_evidence, self.target_model.input_dim))
+        self.init_y = np.zeros((self.n_initial_evidence, 1))
 
         # Initialize state dictionary
         self.state['n_evidence'] = 0
@@ -390,10 +392,19 @@ class BOLFIRE(ModelBased):
         # BO part
         self.state['n_evidence'] += 1
         parameter_values = self.current_params
-        optimize = self._should_optimize()
-        self.target_model.update(parameter_values, negative_log_ratio_value, optimize)
-        if optimize:
-            self.state['last_GP_update'] = self.target_model.n_evidence
+        if self.target_model.n_evidence < 1 and self.n_initial_evidence > 0:
+            # accumulate initialisation data
+            self.init_x[self.state['n_evidence'] - 1] = parameter_values
+            self.init_y[self.state['n_evidence'] - 1] = negative_log_ratio_value
+            if self.state['n_evidence'] >= self.n_initial_evidence:
+                # initialise model
+                self.target_model.update(self.init_x, self.init_y, optimize=True)
+        else:
+            # update model
+            optimize = self._should_optimize()
+            self.target_model.update(parameter_values, negative_log_ratio_value, optimize)
+            if optimize:
+                self.state['last_GP_update'] = self.target_model.n_evidence
 
     def _generate_training_data(self, likelihood, marginal):
         """Generate training data."""


### PR DESCRIPTION
#### Summary:
This update postpones surrogate model initialisation in BOLFI and BOLFIRE until `n_initial_evidence` data points are available and initialises the model based on all this data. Fixes #425 

In the current implementation, the model is initialised based on `batch_size` data points. This is a problem when `batch_size` is small because the priors applied on the default kernel are also determined based on the initialisation data and become sensitive to the random seed. For example, see what happens in BOLFI tutorial notebook with `seed=310522` vs `seed=1` or BOLFIRE tutorial notebook with `seed=100123` vs `seed=10`.

#### Please make sure

- You have read [contribution guidelines](https://elfi.readthedocs.io/en/latest/developer/contributing.html)
- You have updated CHANGELOG.rst
- You have listed the copyright holder for the work you are submitting (see next section)

If your contribution adds, removes or somehow changes the functional behavior of the package, please check that

- You have included or updated all the relevant documentation, including docstrings
- You have added appropriate functional and unit tests to ensure the new features behave as expected
- You have run `make lint`, `make docs` and `make test`

and the proposed changes pass all unit tests (check step 6 of CONTRIBUTING.rst for details)

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD3 (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
